### PR TITLE
【全般】delegate、command処理の命名を修正

### DIFF
--- a/Kikurage/ScreenModule/Communication/BaseView/CommunicationBaseView.swift
+++ b/Kikurage/ScreenModule/Communication/BaseView/CommunicationBaseView.swift
@@ -9,8 +9,7 @@
 import UIKit
 
 protocol CommunicationBaseViewDelegate: AnyObject {
-    /// Facebookボタンを押した時の処理
-    func didTapFacebookButton()
+    func communicationBaseViewDidTapFacebookButton(_ communicationBaseView: CommunicationBaseView)
 }
 
 class CommunicationBaseView: UIView {
@@ -26,8 +25,8 @@ class CommunicationBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapFacebookButton(_ sender: Any) {
-        delegate?.didTapFacebookButton()
+    @IBAction private func openFacebook(_ sender: Any) {
+        delegate?.communicationBaseViewDidTapFacebookButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Communication/ViewController/CommunicationViewController.storyboard
+++ b/Kikurage/ScreenModule/Communication/ViewController/CommunicationViewController.storyboard
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="182.5" y="793" width="49" height="49"/>
                                 <state key="normal" image="facebookButton"/>
                                 <connections>
-                                    <action selector="didTapFacebookButton:" destination="d3D-3V-zZU" eventType="touchUpInside" id="CUz-A3-zlG"/>
+                                    <action selector="openFacebook:" destination="d3D-3V-zZU" eventType="touchUpInside" id="6nl-Cp-C22"/>
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="communication" translatesAutoresizingMaskIntoConstraints="NO" id="PZt-uh-Gv7">

--- a/Kikurage/ScreenModule/Communication/ViewController/CommunicationViewController.swift
+++ b/Kikurage/ScreenModule/Communication/ViewController/CommunicationViewController.swift
@@ -36,7 +36,7 @@ extension CommunicationViewController {
 // MARK: - CommunicationBaseView Delegate
 
 extension CommunicationViewController: CommunicationBaseViewDelegate {
-    func didTapFacebookButton() {
+    func communicationBaseViewDidTapFacebookButton(_ communicationBaseView: CommunicationBaseView) {
         let urlString = AppConfig.shared.facebookGroupUrl
         transitionSafariViewController(urlString: urlString, onError: nil)
     }

--- a/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
+++ b/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
@@ -9,8 +9,7 @@
 import UIKit
 
 protocol CultivationBaseViewDelegate: AnyObject {
-    /// 栽培記録保存画面のボタンをタップした時の処理
-    func didTapPostCultivationPageButton()
+    func cultivationBaseViewDidTapPostCultivationPageButton(_ cultivationBaseView: CultivationBaseView)
 }
 
 class CultivationBaseView: UIView {
@@ -31,8 +30,8 @@ class CultivationBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapPostCultivationPageButton(_ sender: Any) {
-        delegate?.didTapPostCultivationPageButton()
+    @IBAction private func openCultivationPost(_ sender: Any) {
+        delegate?.cultivationBaseViewDidTapPostCultivationPageButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
@@ -38,7 +38,7 @@
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
                                 <connections>
-                                    <action selector="didTapPostCultivationPageButton:" destination="JsX-gy-r0o" eventType="touchUpInside" id="3b9-pK-IBP"/>
+                                    <action selector="openCultivationPost:" destination="JsX-gy-r0o" eventType="touchUpInside" id="q1I-8A-5h7"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
@@ -75,7 +75,7 @@ extension CultivationViewController {
 // MARK: - CultivationBaseView Delegate
 
 extension CultivationViewController: CultivationBaseViewDelegate {
-    func didTapPostCultivationPageButton() {
+    func cultivationBaseViewDidTapPostCultivationPageButton(_ cultivationBaseView: CultivationBaseView) {
         guard let vc = R.storyboard.postCultivationViewController.instantiateInitialViewController() else { return }
         present(vc, animated: true, completion: nil)
     }
@@ -84,17 +84,16 @@ extension CultivationViewController: CultivationBaseViewDelegate {
 // MARK: - CultivationViewModel Delegate
 
 extension CultivationViewController: CultivationViewModelDelegate {
-    func didSuccessGetCultivations() {
+    func cultivationViewModelDidSuccessGetCultivations(_ cultivationViewModel: CultivationViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             self.baseView.collectionView.refreshControl?.endRefreshing()
 
             self.baseView.collectionView.reloadData()
-            self.baseView.noCultivationLabel.isHidden = !(self.viewModel.cultivations.isEmpty)
+            self.baseView.noCultivationLabel.isHidden = !(cultivationViewModel.cultivations.isEmpty)
         }
     }
-    func didFailedGetCultivations(errorMessage: String) {
-        print(errorMessage)
+    func cultivationViewModelDidFailedGetCultivations(_ cultivationViewModel: CultivationViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             self.baseView.collectionView.refreshControl?.endRefreshing()

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -10,11 +10,8 @@ import UIKit.UICollectionView
 import Firebase
 
 protocol CultivationViewModelDelegate: AnyObject {
-    /// きくらげ栽培記録の取得に成功した
-    func didSuccessGetCultivations()
-    /// きくらげ栽培記録の取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetCultivations(errorMessage: String)
+    func cultivationViewModelDidSuccessGetCultivations(_ cultivationViewModel: CultivationViewModel)
+    func cultivationViewModelDidFailedGetCultivations(_ cultivationViewModel: CultivationViewModel, with errorMessage: String)
 }
 class CultivationViewModel: NSObject {
     private let cultivationRepository: CultivationRepositoryProtocol
@@ -52,9 +49,9 @@ extension CultivationViewModel {
             case .success(let cultivations):
                 self?.cultivations = cultivations
                 self?.sortCultivations()
-                self?.delegate?.didSuccessGetCultivations()
+                self?.delegate?.cultivationViewModelDidSuccessGetCultivations(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetCultivations(errorMessage: error.description())
+                self?.delegate?.cultivationViewModelDidFailedGetCultivations(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/Home/BaseView/HomeBaseView.swift
+++ b/Kikurage/ScreenModule/Home/BaseView/HomeBaseView.swift
@@ -169,13 +169,13 @@ extension HomeBaseView {
 // MARK: - FooterButtonView Delegate
 
 extension HomeBaseView: FooterButtonViewDelegate {
-    func footerButtonViewDidTapCultivationButton() {
+    func footerButtonViewDidTapCultivationButton(_ footerButtonView: FooterButtonView) {
         delegate?.homeBaseViewDidTappedCultivationButton(self)
     }
-    func footerButtonViewDidTapRecipeButton() {
+    func footerButtonViewDidTapRecipeButton(_ footerButtonView: FooterButtonView) {
         delegate?.homeBaseViewDidTappedRecipeButton(self)
     }
-    func footerButtonViewDidTapCommunicationButton() {
+    func footerButtonViewDidTapCommunicationButton(_ footerButtonView: FooterButtonView) {
         delegate?.homeBaseViewDidTappedCommunicationButton(self)
     }
 }

--- a/Kikurage/ScreenModule/Home/BaseView/HomeBaseView.swift
+++ b/Kikurage/ScreenModule/Home/BaseView/HomeBaseView.swift
@@ -9,14 +9,10 @@
 import UIKit
 
 protocol HomeBaseViewDelegate: AnyObject {
-    /// 栽培記録ボタンを押した時の処理
-    func didTapCultivationButton()
-    /// 料理記録ボタンを押した時の処理
-    func didTapRecipeButton()
-    /// 相談ボタンを押した時の処理
-    func didTapCommunicationButton()
-    /// サイドメニュー用のハンバーガーアイコンを押した時の処理
-    func didTapSideMenuButton()
+    func homeBaseViewDidTappedCultivationButton(_ homeBaseView: HomeBaseView)
+    func homeBaseViewDidTappedRecipeButton(_ homeBaseView: HomeBaseView)
+    func homeBaseViewDidTappedCommunicationButton(_ homeBaseView: HomeBaseView)
+    func homeBaseViewDidTappedSideMenuButton(_ homeBaseView: HomeBaseView)
 }
 
 class HomeBaseView: UIView {
@@ -53,17 +49,8 @@ class HomeBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapCultivationButton(_ sender: Any) {
-        delegate?.didTapCultivationButton()
-    }
-    @IBAction private func didTapRecipeButton(_ sender: Any) {
-        delegate?.didTapRecipeButton()
-    }
-    @IBAction private func didTapCommunicationButton(_ sender: Any) {
-        delegate?.didTapCommunicationButton()
-    }
-    @IBAction private func didTapSideMenuButton(_ sender: Any) {
-        delegate?.didTapSideMenuButton()
+    @IBAction private func openSideMenu(_ sender: Any) {
+        delegate?.homeBaseViewDidTappedSideMenuButton(self)
     }
 }
 
@@ -183,12 +170,12 @@ extension HomeBaseView {
 
 extension HomeBaseView: FooterButtonViewDelegate {
     func footerButtonViewDidTapCultivationButton() {
-        delegate?.didTapCultivationButton()
+        delegate?.homeBaseViewDidTappedCultivationButton(self)
     }
     func footerButtonViewDidTapRecipeButton() {
-        delegate?.didTapRecipeButton()
+        delegate?.homeBaseViewDidTappedRecipeButton(self)
     }
     func footerButtonViewDidTapCommunicationButton() {
-        delegate?.didTapCommunicationButton()
+        delegate?.homeBaseViewDidTappedCommunicationButton(self)
     }
 }

--- a/Kikurage/ScreenModule/Home/ChildView/FooterButtonView.swift
+++ b/Kikurage/ScreenModule/Home/ChildView/FooterButtonView.swift
@@ -10,9 +10,9 @@ import UIKit
 import FontAwesome_swift
 
 protocol FooterButtonViewDelegate: AnyObject {
-    func footerButtonViewDidTapCultivationButton()
-    func footerButtonViewDidTapRecipeButton()
-    func footerButtonViewDidTapCommunicationButton()
+    func footerButtonViewDidTapCultivationButton(_ footerButtonView: FooterButtonView)
+    func footerButtonViewDidTapRecipeButton(_ footerButtonView: FooterButtonView)
+    func footerButtonViewDidTapCommunicationButton(_ footerButtonView: FooterButtonView)
 }
 
 class FooterButtonView: UIView {
@@ -72,13 +72,13 @@ class FooterButtonView: UIView {
     // MARK: - Action
 
     @objc private func onCultivation(_ sender: UIButton) {
-        delegate?.footerButtonViewDidTapCultivationButton()
+        delegate?.footerButtonViewDidTapCultivationButton(self)
     }
     @objc private func onRecipe(_ sender: UIButton) {
-        delegate?.footerButtonViewDidTapRecipeButton()
+        delegate?.footerButtonViewDidTapRecipeButton(self)
     }
     @objc private func onCommunication(_ sender: UIButton) {
-        delegate?.footerButtonViewDidTapCommunicationButton()
+        delegate?.footerButtonViewDidTapCommunicationButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Home/ViewController/Base.lproj/HomeViewController.storyboard
+++ b/Kikurage/ScreenModule/Home/ViewController/Base.lproj/HomeViewController.storyboard
@@ -210,7 +210,7 @@
                     <navigationItem key="navigationItem" id="TeJ-IM-bD8">
                         <barButtonItem key="leftBarButtonItem" image="line.horizontal.3" catalog="system" id="v7k-rS-zX6">
                             <connections>
-                                <action selector="didTapSideMenuButton:" destination="fri-rL-faW" id="qsh-Fy-CJ8"/>
+                                <action selector="openSideMenu:" destination="fri-rL-faW" id="dzX-yO-IPw"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/Kikurage/ScreenModule/Home/ViewController/HomeViewController.swift
+++ b/Kikurage/ScreenModule/Home/ViewController/HomeViewController.swift
@@ -104,19 +104,19 @@ extension HomeViewController {
 // MARK: - HomeBaseView Delegate
 
 extension HomeViewController: HomeBaseViewDelegate {
-    func didTapCultivationButton() {
+    func homeBaseViewDidTappedCultivationButton(_ homeBaseView: HomeBaseView) {
         guard let vc = R.storyboard.cultivationViewController.instantiateInitialViewController() else { return }
         navigationController?.pushViewController(vc, animated: true)
     }
-    func didTapRecipeButton() {
+    func homeBaseViewDidTappedRecipeButton(_ homeBaseView: HomeBaseView) {
         guard let vc = R.storyboard.recipeViewController.instantiateInitialViewController() else { return }
         navigationController?.pushViewController(vc, animated: true)
     }
-    func didTapCommunicationButton() {
+    func homeBaseViewDidTappedCommunicationButton(_ homeBaseView: HomeBaseView) {
         guard let vc = R.storyboard.communicationViewController.instantiateInitialViewController() else { return }
         navigationController?.pushViewController(vc, animated: true)
     }
-    func didTapSideMenuButton() {
+    func homeBaseViewDidTappedSideMenuButton(_ homeBaseView: HomeBaseView) {
         performSegue(withIdentifier: R.segue.homeViewController.sideMenu.identifier, sender: nil)
     }
 }
@@ -124,19 +124,19 @@ extension HomeViewController: HomeBaseViewDelegate {
 // MARK: - HomeViewModel Delegate
 
 extension HomeViewController: HomeViewModelDelgate {
-    func didSuccessGetKikurageState() {
+    func homeViewModelDidSuccessGetKikurageState(_ homeViewModel: HomeViewModel) {
         DispatchQueue.main.async {
-            self.baseView.setKikurageStateUI(kikurageState: self.viewModel.kikurageState)
+            self.baseView.setKikurageStateUI(kikurageState: homeViewModel.kikurageState)
         }
     }
-    func didFailedGetKikurageState(errorMessage: String) {
+    func homeViewModelDidFailedGetKikurageState(_ homeViewModel: HomeViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil) { [weak self] in
-                self?.baseView.setKikurageStateUI(kikurageState: self?.viewModel.kikurageState)
+                self?.baseView.setKikurageStateUI(kikurageState: homeViewModel.kikurageState)
             }
         }
     }
-    func didChangedKikurageState() {
-        baseView.setKikurageStateUI(kikurageState: viewModel.kikurageState)
+    func homeViewModelDidChangedKikurageState(_ homeViewModel: HomeViewModel) {
+        baseView.setKikurageStateUI(kikurageState: homeViewModel.kikurageState)
     }
 }

--- a/Kikurage/ScreenModule/Home/ViewModel/HomeViewModel.swift
+++ b/Kikurage/ScreenModule/Home/ViewModel/HomeViewModel.swift
@@ -9,13 +9,9 @@
 import Foundation
 
 protocol HomeViewModelDelgate: AnyObject {
-    /// きくらげの状態データ取得に成功した
-    func didSuccessGetKikurageState()
-    /// きくらげの状態データ取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageState(errorMessage: String)
-    /// きくらげの状態データが更新された
-    func didChangedKikurageState()
+    func homeViewModelDidSuccessGetKikurageState(_ homeViewModel: HomeViewModel)
+    func homeViewModelDidFailedGetKikurageState(_ homeViewModel: HomeViewModel, with errorMessage: String)
+    func homeViewModelDidChangedKikurageState(_ homeViewModel: HomeViewModel)
 }
 
 class HomeViewModel {
@@ -50,15 +46,15 @@ extension HomeViewModel {
 extension HomeViewModel {
     /// きくらげの状態を読み込む
     func loadKikurageState() {
-        kikurageStateRepository.getKikurageState(productId: kikurageUser.productKey) { response in
+        kikurageStateRepository.getKikurageState(productId: kikurageUser.productKey) { [weak self] response in
             switch response {
             case .success(let kikurageState):
-                self.kikurageState = kikurageState
-                self.kikurageState.convertToStateType()
-                self.delegate?.didSuccessGetKikurageState()
+                self?.kikurageState = kikurageState
+                self?.kikurageState.convertToStateType()
+                self?.delegate?.homeViewModelDidSuccessGetKikurageState(self!)
             case .failure(let error):
-                self.kikurageState = nil
-                self.delegate?.didFailedGetKikurageState(errorMessage: error.description())
+                self?.kikurageState = nil
+                self?.delegate?.homeViewModelDidFailedGetKikurageState(self!, with: error.description())
             }
         }
     }
@@ -69,7 +65,7 @@ extension HomeViewModel {
             case .success(let kikurageState):
                 self?.kikurageState = kikurageState
                 self?.kikurageState.convertToStateType()
-                self?.delegate?.didChangedKikurageState()
+                self?.delegate?.homeViewModelDidChangedKikurageState(self!)
             case .failure(let error):
                 self?.kikurageState = nil
                 fatalError(error.description())

--- a/Kikurage/ScreenModule/Login/BaseView/DeviceRegisterBaseView.swift
+++ b/Kikurage/ScreenModule/Login/BaseView/DeviceRegisterBaseView.swift
@@ -9,8 +9,7 @@
 import UIKit
 
 protocol DeviceRegisterBaseViewDelegate: AnyObject {
-    /// ログインボタンを押した時の処理
-    func didTappedDeviceRegisterButton()
+    func deviceRegisterBaseViewDidTappedDeviceRegisterButton(_ deviceRegisterBaseView: DeviceRegisterBaseView)
 }
 
 class DeviceRegisterBaseView: UIView {
@@ -31,8 +30,8 @@ class DeviceRegisterBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTappedDeviceRegisterButton(_ sender: Any) {
-        delegate?.didTappedDeviceRegisterButton()
+    @IBAction private func registerDevice(_ sender: Any) {
+        delegate?.deviceRegisterBaseViewDidTappedDeviceRegisterButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Login/BaseView/LoginBaseView.swift
+++ b/Kikurage/ScreenModule/Login/BaseView/LoginBaseView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol LoginBaseViewDelegate: AnyObject {
-    func didTappedLoginButton()
+    func loginBaseViewDidTappedLoginButton(_ loginBaseView: LoginBaseView)
 }
 
 class LoginBaseView: UIView {
@@ -26,8 +26,8 @@ class LoginBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTappedLoginButton(_ sender: Any) {
-        delegate?.didTappedLoginButton()
+    @IBAction private func login(_ sender: Any) {
+        delegate?.loginBaseViewDidTappedLoginButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Login/BaseView/SignUpBaseView.swift
+++ b/Kikurage/ScreenModule/Login/BaseView/SignUpBaseView.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol SignUpBaseViewDelegate: AnyObject {
-    func didTappedUserRegisterButton()
+    func signUpBaseViewDidTappedRegisterUserButton(_ signUpBaseView: SignUpBaseView)
 }
 
 class SignUpBaseView: UIView {
@@ -26,8 +26,8 @@ class SignUpBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTappedUserRegisterButton(_ sender: Any) {
-        delegate?.didTappedUserRegisterButton()
+    @IBAction private func registerUser(_ sender: Any) {
+        delegate?.signUpBaseViewDidTappedRegisterUserButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Login/ViewController/DeviceRegisterViewController.storyboard
+++ b/Kikurage/ScreenModule/Login/ViewController/DeviceRegisterViewController.storyboard
@@ -25,7 +25,7 @@
                                 </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                 <connections>
-                                    <action selector="didTappedDeviceRegisterButton:" destination="bkR-99-1oz" eventType="touchUpInside" id="KlO-sN-faH"/>
+                                    <action selector="registerDevice:" destination="bkR-99-1oz" eventType="touchUpInside" id="y9W-eQ-3xr"/>
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="v2y-Sg-EvC">

--- a/Kikurage/ScreenModule/Login/ViewController/DeviceRegisterViewController.swift
+++ b/Kikurage/ScreenModule/Login/ViewController/DeviceRegisterViewController.swift
@@ -69,7 +69,7 @@ extension DeviceRegisterViewController: UITextFieldDelegate {
 // MARK: - DeviceRegisterBaseView Delegate
 
 extension DeviceRegisterViewController: DeviceRegisterBaseViewDelegate {
-    func didTappedDeviceRegisterButton() {
+    func deviceRegisterBaseViewDidTappedDeviceRegisterButton(_ deviceRegisterBaseView: DeviceRegisterBaseView) {
         let validate = textFieldValidation()
         if validate {
             HUD.show(.progress)
@@ -95,22 +95,22 @@ extension DeviceRegisterViewController: DeviceRegisterBaseViewDelegate {
 // MARK: - LoginViewModel Delegate
 
 extension DeviceRegisterViewController: DeviceRegisterViewModelDelegate {
-    func didSuccessGetKikurageState() {
-        viewModel.registerKikurageUser()
+    func deviceRegisterViewModelDidSuccessGetKikurageState(_ deviceRegisterViewModel: DeviceRegisterViewModel) {
+        deviceRegisterViewModel.registerKikurageUser()
     }
-    func didFailedGetKikurageState(errorMessage: String) {
+    func deviceRegisterViewModelDidFailedGetKikurageState(_ deviceRegisterViewMode: DeviceRegisterViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: "OK", cancelButtonTitle: nil, completionOk: nil)
         }
     }
-    func didSuccessPostKikurageUser() {
+    func deviceRegisterViewModelDidSuccessPostKikurageUser(_ deviceRegisterViewModel: DeviceRegisterViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             self.transitionHomePage()
         }
     }
-    func didFailedPostKikurageUser(errorMessage: String) {
+    func deviceRegisterViewModelDidFailedPostKikurageUser(_ deviceRegisterViewModel: DeviceRegisterViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: "OK", cancelButtonTitle: nil, completionOk: nil)

--- a/Kikurage/ScreenModule/Login/ViewController/LoginViewController.storyboard
+++ b/Kikurage/ScreenModule/Login/ViewController/LoginViewController.storyboard
@@ -38,7 +38,7 @@
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTappedLoginButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="3GA-AT-cMh"/>
+                                    <action selector="login:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="ehD-LN-MwD"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/ScreenModule/Login/ViewController/LoginViewController.swift
@@ -37,7 +37,7 @@ extension LoginViewController {
 // MARK: - LoginBaseView Delegate
 
 extension LoginViewController: LoginBaseViewDelegate {
-    func didTappedLoginButton() {
+    func loginBaseViewDidTappedLoginButton(_ loginBaseView: LoginBaseView) {
         HUD.show(.progress)
         viewModel.login()
     }
@@ -62,18 +62,18 @@ extension LoginViewController: UITextFieldDelegate {
 // MARK: - LoginViewModel Delegate
 
 extension LoginViewController: LoginViewModelDelegate {
-    func didSuccessLogin() {
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             self.transitionHomePage()
         }
     }
-    func didFailedLogin(errorMessage: String) {
+    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: errorMessage, okButtonTitle: "OK", cancelButtonTitle: nil) { [weak self] in
                 self?.baseView.initTextFields()
-                self?.viewModel.initLoginInfo()
+                loginViewModel.initLoginInfo()
             }
         }
     }

--- a/Kikurage/ScreenModule/Login/ViewController/SignUpViewController.storyboard
+++ b/Kikurage/ScreenModule/Login/ViewController/SignUpViewController.storyboard
@@ -18,17 +18,17 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="kFy-af-4H6">
-                                <rect key="frame" x="40" y="84" width="334" height="34"/>
+                                <rect key="frame" x="40" y="40" width="520" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yeG-aM-GHB">
-                                <rect key="frame" x="40" y="143" width="334" height="34"/>
+                                <rect key="frame" x="40" y="99" width="520" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PEV-CC-gRf">
-                                <rect key="frame" x="40" y="212" width="334" height="45"/>
+                                <rect key="frame" x="40" y="168" width="520" height="45"/>
                                 <color key="backgroundColor" name="subColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="45" id="IT7-Mz-yrY"/>
@@ -38,7 +38,7 @@
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTappedUserRegisterButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="r2L-4c-aal"/>
+                                    <action selector="registerUser:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="wf0-ZY-sYd"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/Login/ViewController/SignUpViewController.swift
+++ b/Kikurage/ScreenModule/Login/ViewController/SignUpViewController.swift
@@ -42,7 +42,7 @@ extension SignUpViewController {
 // MARK: - SignUpBaseView Delegate
 
 extension SignUpViewController: SignUpBaseViewDelegate {
-    func didTappedUserRegisterButton() {
+    func signUpBaseViewDidTappedRegisterUserButton(_ signUpBaseView: SignUpBaseView) {
         HUD.show(.progress)
         viewModel.registerUser()
     }
@@ -67,7 +67,7 @@ extension SignUpViewController: UITextFieldDelegate {
 // MARK: - SignUpViewModel Delegate
 
 extension SignUpViewController: SignUpViewModelDelegate {
-    func didSuccessRegisterUser() {
+    func signUpViewModelDidSuccessRegisterUser(_ signUpViewModel: SignUpViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: "仮登録完了", message: "入力したメールアドレスに送ったリンクから本登録を行い次へ進んでください", okButtonTitle: "次へ", cancelButtonTitle: nil) {
@@ -78,11 +78,11 @@ extension SignUpViewController: SignUpViewModelDelegate {
             }
         }
     }
-    func didFailedRegisterUser(errorMessage: String) {
+    func signUpViewModelDidFailedRegisterUser(_ signUpViewModel: SignUpViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: errorMessage, okButtonTitle: "OK", cancelButtonTitle: nil) {
-                self.viewModel.initUserInfo()
+                signUpViewModel.initUserInfo()
                 self.baseView.initTextFields()
             }
         }

--- a/Kikurage/ScreenModule/Login/ViewModel/DeviceRegisterViewModel.swift
+++ b/Kikurage/ScreenModule/Login/ViewModel/DeviceRegisterViewModel.swift
@@ -10,16 +10,10 @@ import UIKit
 import Firebase
 
 protocol DeviceRegisterViewModelDelegate: AnyObject {
-    /// きくらげの状態データ取得に成功した
-    func didSuccessGetKikurageState()
-    /// きくらげの状態データ取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageState(errorMessage: String)
-    /// きくらげユーザーの登録に成功した
-    func didSuccessPostKikurageUser()
-    /// きくらげユーザーの登録に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedPostKikurageUser(errorMessage: String)
+    func deviceRegisterViewModelDidSuccessGetKikurageState(_ deviceRegisterViewModel: DeviceRegisterViewModel)
+    func deviceRegisterViewModelDidFailedGetKikurageState(_ deviceRegisterViewMode: DeviceRegisterViewModel, with errorMessage: String)
+    func deviceRegisterViewModelDidSuccessPostKikurageUser(_ deviceRegisterViewModel: DeviceRegisterViewModel)
+    func deviceRegisterViewModelDidFailedPostKikurageUser(_ deviceRegisterViewModel: DeviceRegisterViewModel, with errorMessage: String)
 }
 
 class DeviceRegisterViewModel {
@@ -58,26 +52,26 @@ extension DeviceRegisterViewModel {
             switch response {
             case .success(let kikurageState):
                 self?.kikurageState = kikurageState
-                self?.delegate?.didSuccessGetKikurageState()
+                self?.delegate?.deviceRegisterViewModelDidSuccessGetKikurageState(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageState(errorMessage: error.description())
+                self?.delegate?.deviceRegisterViewModelDidFailedGetKikurageState(self!, with: error.description())
             }
         }
     }
     /// きくらげユーザーを登録する
     func registerKikurageUser() {
         guard let kikurageUser = kikurageUser else {
-            delegate?.didFailedPostKikurageUser(errorMessage: R.string.localizable.common_load_user_error())
+            delegate?.deviceRegisterViewModelDidFailedPostKikurageUser(self, with: R.string.localizable.common_load_user_error())
             return
         }
         guard let uid = LoginHelper.shared.kikurageUserId else { return }
         kikurageUserRepository.postKikurageUser(uid: uid, kikurageUser: kikurageUser) { [weak self] responsse in
             switch responsse {
             case .success():
-                self?.delegate?.didSuccessPostKikurageUser()
+                self?.delegate?.deviceRegisterViewModelDidSuccessPostKikurageUser(self!)
                 self?.kikurageUser = kikurageUser
             case .failure(let error):
-                self?.delegate?.didFailedPostKikurageUser(errorMessage: error.description())
+                self?.delegate?.deviceRegisterViewModelDidFailedPostKikurageUser(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/ScreenModule/Login/ViewModel/LoginViewModel.swift
@@ -9,11 +9,8 @@
 import Foundation
 
 protocol LoginViewModelDelegate: AnyObject {
-    /// ログインに成功した
-    func didSuccessLogin()
-    /// ログインに失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedLogin(errorMessage: String)
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel)
+    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel, with errorMessage: String)
 }
 
 class LoginViewModel {
@@ -63,7 +60,7 @@ extension LoginViewModel {
                 self?.loginUser = loginUser
                 self?.loadKikurageUser()
             case .failure(let error):
-                self?.delegate?.didFailedLogin(errorMessage: error.description())
+                self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
             }
         }
     }
@@ -80,7 +77,7 @@ extension LoginViewModel {
                 self?.kikurageUser = kikurageUser
                 self?.loadKikurageState()
             case .failure(let error):
-                self?.delegate?.didFailedLogin(errorMessage: error.description())
+                self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
             }
         }
     }
@@ -91,9 +88,9 @@ extension LoginViewModel {
             switch response {
             case .success(let kikurageState):
                 self?.kikurageState = kikurageState
-                self?.delegate?.didSuccessLogin()
+                self?.delegate?.loginViewModelDidSuccessLogin(self!)
             case .failure(let error):
-                self?.delegate?.didFailedLogin(errorMessage: error.description())
+                self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/Login/ViewModel/SignUpViewModel.swift
+++ b/Kikurage/ScreenModule/Login/ViewModel/SignUpViewModel.swift
@@ -9,11 +9,8 @@
 import Foundation
 
 protocol SignUpViewModelDelegate: AnyObject {
-    /// ユーザー登録に成功した
-    func didSuccessRegisterUser()
-    /// ユーザー登録に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedRegisterUser(errorMessage: String)
+    func signUpViewModelDidSuccessRegisterUser(_ signUpViewModel: SignUpViewModel)
+    func signUpViewModelDidFailedRegisterUser(_ signUpViewModel: SignUpViewModel, with errorMessage: String)
 }
 
 class SignUpViewModel {
@@ -53,9 +50,9 @@ extension SignUpViewModel {
             switch response {
             case .success(let loginUser):
                 self?.loginUser = loginUser
-                self?.delegate?.didSuccessRegisterUser()
+                self?.delegate?.signUpViewModelDidSuccessRegisterUser(self!)
             case .failure(let error):
-                self?.delegate?.didFailedRegisterUser(errorMessage: error.description())
+                self?.delegate?.signUpViewModelDidFailedRegisterUser(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/PostCultivation/BaseView/PostCultivationBaseView.swift
+++ b/Kikurage/ScreenModule/PostCultivation/BaseView/PostCultivationBaseView.swift
@@ -9,10 +9,8 @@
 import UIKit
 
 protocol PostCultivationBaseViewDelegate: AnyObject {
-    /// 栽培記録保存するボタンを押した時の処理
-    func didTapPostButton()
-    /// 閉じるボタンを押した時の処理
-    func didTapCloseButton()
+    func postCultivationBaseViewDidTappedPostButton(_ postCultivationBaseView: PostCultivationBaseView)
+    func postCultivationBaseViewDidTappedCloseButton(_ postCultivationBaseView: PostCultivationBaseView)
 }
 
 class PostCultivationBaseView: UIView {
@@ -41,11 +39,11 @@ class PostCultivationBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapPostButton(_ sender: Any) {
-        delegate?.didTapPostButton()
+    @IBAction private func post(_ sender: Any) {
+        delegate?.postCultivationBaseViewDidTappedPostButton(self)
     }
-    @IBAction private func didTapCloseButton(_ sender: Any) {
-        delegate?.didTapCloseButton()
+    @IBAction private func close(_ sender: Any) {
+        delegate?.postCultivationBaseViewDidTappedCloseButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.storyboard
+++ b/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5X-xd-GP8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5X-xd-GP8">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -13,8 +13,8 @@
         <!--Post Cultivation View Controller-->
         <scene sceneID="wVv-eq-XKh">
             <objects>
-                <viewController id="x5X-xd-GP8" customClass="PostCultivationViewController" customModule="きくらげ君" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="IvK-fa-IF2" customClass="PostCultivationBaseView" customModule="きくらげ君" customModuleProvider="target">
+                <viewController id="x5X-xd-GP8" customClass="PostCultivationViewController" customModule="Kikurage" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="IvK-fa-IF2" customClass="PostCultivationBaseView" customModule="Kikurage" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -25,7 +25,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="b4s-6e-QMy">
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <connections>
-                                                <action selector="didTapCloseButton:" destination="IvK-fa-IF2" id="brB-1M-plX"/>
+                                                <action selector="close:" destination="IvK-fa-IF2" id="dic-tI-ce2"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -45,7 +45,7 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ev5-t0-9pB" customClass="UITextViewWithPlaceholder" customModule="きくらげ君" customModuleProvider="target">
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ev5-t0-9pB" customClass="UITextViewWithPlaceholder" customModule="Kikurage" customModuleProvider="target">
                                 <rect key="frame" x="8" y="313" width="398" height="50"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -101,7 +101,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTapPostButton:" destination="IvK-fa-IF2" eventType="touchUpInside" id="lex-K9-v8b"/>
+                                    <action selector="post:" destination="IvK-fa-IF2" eventType="touchUpInside" id="vIj-Di-hYs"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.swift
+++ b/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.swift
@@ -42,7 +42,7 @@ extension PostCultivationViewController {
 // MARK: - PostCultivatioBaseView Delegate
 
 extension PostCultivationViewController: PostCultivationBaseViewDelegate {
-    func didTapPostButton() {
+    func postCultivationBaseViewDidTappedPostButton(_ postCultivationBaseView: PostCultivationBaseView) {
         UIAlertController.showAlert(style: .alert, viewController: self, title: R.string.localizable.screen_post_cultivation_alert_post_cultivation_title(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: R.string.localizable.common_alert_cancel_btn_cancel()) {
             // HUD表示（始）
             HUD.show(.progress)
@@ -51,7 +51,7 @@ extension PostCultivationViewController: PostCultivationBaseViewDelegate {
             }
         }
     }
-    func didTapCloseButton() {
+    func postCultivationBaseViewDidTappedCloseButton(_ postCultivationBaseView: PostCultivationBaseView) {
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
@@ -83,7 +83,9 @@ extension PostCultivationViewController: UITextViewDelegate {
         baseView.setCurrentTextViewNumber(text: text)
     }
 }
+
 // MARK: - CameraCell Delegate
+
 extension PostCultivationViewController: CameraCellDelegate {
     func didTapImageCancelButton(cell: CameraCell) {
         let index = cell.tag
@@ -91,9 +93,11 @@ extension PostCultivationViewController: CameraCellDelegate {
         baseView.cameraCollectionView.reloadItems(at: [IndexPath(row: index, section: 0)])
     }
 }
+
 // MARK: - PostCultivationViewModel Delegate
+
 extension PostCultivationViewController: PostCultivationViewModelDelegate {
-    func didSuccessPostCultivation() {
+    func postCultivationViewModelDidSuccessPostCultivation(_ postCultivationViewModel: PostCultivationViewModel) {
         // nil要素を取り除いた選択した画像のみのData型に変換する
         let postImageData: [Data?] = cameraCollectionViewModel.changeToImageData(compressionQuality: 0.8).filter { $0 != nil }
         // Firestoreにデータ登録後、そのdocumentIDをパスに使ってStorageへ画像を投稿する
@@ -101,13 +105,13 @@ extension PostCultivationViewController: PostCultivationViewModelDelegate {
             viewModel.postCultivationImages(kikurageUserId: kikurageUserId, imageData: postImageData)
         }
     }
-    func didFailedPostCultivation(errorMessage: String) {
+    func postCultivationViewModelDidFailedPostCultivation(_ postCultivationViewModel: PostCultivationViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }
     }
-    func didSuccessPostCultivationImages() {
+    func postCultivationViewModelDidSuccessPostCultivationImages(_ postCultivationViewModel: PostCultivationViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: R.string.localizable.screen_post_cultivation_alert_post_cultivation_success_title(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil) {
@@ -116,20 +120,24 @@ extension PostCultivationViewController: PostCultivationViewModelDelegate {
             }
         }
     }
-    func didFailedPostCultivationImages(errorMessage: String) {
+    func postCultivationViewModelDidFailedPostCultivationImages(_ postCultivationViewModel: PostCultivationViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.screen_post_cultivation_alert_post_cultivation_success_title(), cancelButtonTitle: nil, completionOk: nil)
         }
     }
 }
+
 // MARK: - UICollectionView Delegate
+
 extension PostCultivationViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         openImagePicker()
     }
 }
+
 // MARK: - UIImagePickerController Delegate
+
 extension PostCultivationViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         guard let originalImage = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else { return }

--- a/Kikurage/ScreenModule/PostCultivation/ViewModel/PostCultivationViewModel.swift
+++ b/Kikurage/ScreenModule/PostCultivation/ViewModel/PostCultivationViewModel.swift
@@ -9,16 +9,10 @@
 import Foundation
 
 protocol PostCultivationViewModelDelegate: AnyObject {
-    /// 栽培記録の投稿に成功した
-    func didSuccessPostCultivation()
-    /// 栽培記録の投稿に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedPostCultivation(errorMessage: String)
-    /// 栽培記録画像の投稿に成功した
-    func didSuccessPostCultivationImages()
-    /// 栽培記録画像の投稿に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedPostCultivationImages(errorMessage: String)
+    func postCultivationViewModelDidSuccessPostCultivation(_ postCultivationViewModel: PostCultivationViewModel)
+    func postCultivationViewModelDidFailedPostCultivation(_ postCultivationViewModel: PostCultivationViewModel, with errorMessage: String)
+    func postCultivationViewModelDidSuccessPostCultivationImages(_ postCultivationViewModel: PostCultivationViewModel)
+    func postCultivationViewModelDidFailedPostCultivationImages(_ postCultivationViewModel: PostCultivationViewModel, with errorMessage: String)
 }
 class PostCultivationViewModel {
     private let cultivationRepository: CultivationRepositoryProtocol
@@ -43,9 +37,9 @@ extension PostCultivationViewModel {
             switch response {
             case .success(let documentReference):
                 self?.postedCultivationDocumentId = documentReference.documentID
-                self?.delegate?.didSuccessPostCultivation()
+                self?.delegate?.postCultivationViewModelDidSuccessPostCultivation(self!)
             case .failure(let error):
-                self?.delegate?.didFailedPostCultivation(errorMessage: error.description())
+                self?.delegate?.postCultivationViewModelDidFailedPostCultivation(self!, with: error.description())
             }
         }
     }
@@ -54,9 +48,9 @@ extension PostCultivationViewModel {
             switch response {
             case .success(let imageStorageFullPaths):
                 self?.cultivation.imageStoragePaths = imageStorageFullPaths
-                self?.delegate?.didSuccessPostCultivationImages()
+                self?.delegate?.postCultivationViewModelDidSuccessPostCultivationImages(self!)
             case .failure(let error):
-                self?.delegate?.didFailedPostCultivation(errorMessage: error.description())
+                self?.delegate?.postCultivationViewModelDidFailedPostCultivation(self!, with: error.description())
             }
         }
     }
@@ -67,7 +61,7 @@ extension PostCultivationViewModel {
 extension PostCultivationViewModel {
     func postCultivationImages(kikurageUserId: String, imageData: [Data?]) {
         guard let postedCultivationDocumentId = postedCultivationDocumentId else {
-            delegate?.didFailedPostCultivationImages(errorMessage: FirebaseAPIError.documentIdError.description())
+            delegate?.postCultivationViewModelDidFailedPostCultivationImages(self, with: FirebaseAPIError.documentIdError.description())
             return
         }
         let imageStoragePath = "\(Constants.FirestoreCollectionName.users)/\(kikurageUserId)/\(Constants.FirestoreCollectionName.cultivations)/\(postedCultivationDocumentId)/images/"
@@ -76,7 +70,7 @@ extension PostCultivationViewModel {
             case .success(let imageStorageFullPaths):
                 self?.putCultivationImages(kikurageUserId: kikurageUserId, firestoreDocumentId: postedCultivationDocumentId, imageStorageFullPaths: imageStorageFullPaths)
             case .failure(let error):
-                self?.delegate?.didFailedPostCultivationImages(errorMessage: error.description())
+                self?.delegate?.postCultivationViewModelDidFailedPostCultivationImages(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/PostRecipe/BaseView/PostRecipeBaseView.swift
+++ b/Kikurage/ScreenModule/PostRecipe/BaseView/PostRecipeBaseView.swift
@@ -9,10 +9,8 @@
 import UIKit
 
 protocol PostRecipeBaseViewDelegate: AnyObject {
-    /// 料理記録を保存するボタンを押した時の処理
-    func didTapPostButton()
-    /// 閉じるボタンを押した時の処理
-    func didTapCloseButton()
+    func postRecipeBaseViewDidTappedPostButton(_ postRecipeBaseView: PostRecipeBaseView)
+    func postRecipeBaseViewDidTappedCloseButton(_ postRecipeBaseView: PostRecipeBaseView)
 }
 
 class PostRecipeBaseView: UIView {
@@ -44,11 +42,11 @@ class PostRecipeBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapCloseButton(_ sender: Any) {
-        delegate?.didTapCloseButton()
+    @IBAction private func close(_ sender: Any) {
+        delegate?.postRecipeBaseViewDidTappedCloseButton(self)
     }
-    @IBAction private func didTapPostButton(_ sender: Any) {
-        delegate?.didTapPostButton()
+    @IBAction private func post(_ sender: Any) {
+        delegate?.postRecipeBaseViewDidTappedPostButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.storyboard
+++ b/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.storyboard
@@ -25,7 +25,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="Rrb-DO-HFe">
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <connections>
-                                                <action selector="didTapCloseButton:" destination="50A-5Z-sZQ" id="o5g-Lj-MJu"/>
+                                                <action selector="close:" destination="50A-5Z-sZQ" id="Ako-vn-JXN"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -136,7 +136,7 @@
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTapPostButton:" destination="50A-5Z-sZQ" eventType="touchUpInside" id="HaU-ny-grY"/>
+                                    <action selector="post:" destination="50A-5Z-sZQ" eventType="touchUpInside" id="l0f-mY-cZ8"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.swift
+++ b/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.swift
@@ -41,7 +41,7 @@ extension PostRecipeViewController {
 // MARK: - PostRecipeBaseView Delegate
 
 extension PostRecipeViewController: PostRecipeBaseViewDelegate {
-    func didTapPostButton() {
+    func postRecipeBaseViewDidTappedPostButton(_ postRecipeBaseView: PostRecipeBaseView) {
         UIAlertController.showAlert(style: .alert, viewController: self, title: R.string.localizable.screen_post_recipe_alert_post_recipe_title(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: R.string.localizable.common_alert_cancel_btn_cancel()) {
             HUD.show(.progress)
             if let kikurageUserId = LoginHelper.shared.kikurageUserId {
@@ -49,7 +49,7 @@ extension PostRecipeViewController: PostRecipeBaseViewDelegate {
             }
         }
     }
-    func didTapCloseButton() {
+    func postRecipeBaseViewDidTappedCloseButton(_ postRecipeBaseView: PostRecipeBaseView) {
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
@@ -90,7 +90,9 @@ extension PostRecipeViewController: UITextFieldDelegate {
         viewModel.recipe.name = recipeName
     }
 }
+
 // MARK: - UITextView Delegate
+
 extension PostRecipeViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         var resultText = ""
@@ -144,21 +146,21 @@ extension PostRecipeViewController: UIImagePickerControllerDelegate, UINavigatio
 // MARK: - PostRecipeViewModel Delegate
 
 extension PostRecipeViewController: PostRecipeViewModelDelegate {
-    func didSuccessPostRecipe() {
+    func postRecipeViewModelDidSuccessPostRecipe(_ postRecipeViewModel: PostRecipeViewModel) {
         // nil要素を取り除き、選択した画像のみData型に変換する
         let postIamgeData: [Data?] = cameraCollectionViewModel.changeToImageData(compressionQuality: 0.5).filter { $0 != nil }
         // Firestoreにデータ登録後、そのdocumentIDをパスに使ってStorageへ画像を投稿する
         if let kikurageUserId = LoginHelper.shared.kikurageUserId {
-            viewModel.postRecipeImages(kikurageUserId: kikurageUserId, imageData: postIamgeData)
+            postRecipeViewModel.postRecipeImages(kikurageUserId: kikurageUserId, imageData: postIamgeData)
         }
     }
-    func didFailedPostRecipe(errorMessage: String) {
+    func postRecipeViewModelDidFailedPostRecipe(_ postRecipeViewModel: PostRecipeViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }
     }
-    func didSuccessPostRecipeImages() {
+    func postRecipeViewModelDidSuccessPostRecipeImages(_ postRecipeViewModel: PostRecipeViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: R.string.localizable.screen_post_recipe_alert_post_recipe_success_title(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil) {
@@ -167,7 +169,7 @@ extension PostRecipeViewController: PostRecipeViewModelDelegate {
             }
         }
     }
-    func didFailedPostRecipeImages(errorMessage: String) {
+    func postRecipeViewModelDidFailedPostRecipeImages(_ postRecipeViewModel: PostRecipeViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)

--- a/Kikurage/ScreenModule/PostRecipe/ViewModel/PostRecipeViewModel.swift
+++ b/Kikurage/ScreenModule/PostRecipe/ViewModel/PostRecipeViewModel.swift
@@ -9,16 +9,10 @@
 import Foundation
 
 protocol PostRecipeViewModelDelegate: AnyObject {
-    /// 料理記録の投稿に成功した
-    func didSuccessPostRecipe()
-    /// 料理記録の投稿に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedPostRecipe(errorMessage: String)
-    /// 料理記録画像の投稿に成功した
-    func didSuccessPostRecipeImages()
-    /// 料理記録画像の投稿に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedPostRecipeImages(errorMessage: String)
+    func postRecipeViewModelDidSuccessPostRecipe(_ postRecipeViewModel: PostRecipeViewModel)
+    func postRecipeViewModelDidFailedPostRecipe(_ postRecipeViewModel: PostRecipeViewModel, with errorMessage: String)
+    func postRecipeViewModelDidSuccessPostRecipeImages(_ postRecipeViewModel: PostRecipeViewModel)
+    func postRecipeViewModelDidFailedPostRecipeImages(_ postRecipeViewModel: PostRecipeViewModel, with errorMessage: String)
 }
 
 class PostRecipeViewModel {
@@ -44,9 +38,9 @@ extension PostRecipeViewModel {
             switch response {
             case .success(let documentReference):
                 self?.postedRecipeDocumentId = documentReference.documentID
-                self?.delegate?.didSuccessPostRecipe()
+                self?.delegate?.postRecipeViewModelDidSuccessPostRecipe(self!)
             case .failure(let error):
-                self?.delegate?.didFailedPostRecipe(errorMessage: error.description())
+                self?.delegate?.postRecipeViewModelDidFailedPostRecipe(self!, with: error.description())
             }
         }
     }
@@ -55,9 +49,9 @@ extension PostRecipeViewModel {
             switch response {
             case .success(let imageStorageFullPaths):
                 self?.recipe.imageStoragePaths = imageStorageFullPaths
-                self?.delegate?.didSuccessPostRecipeImages()
+                self?.delegate?.postRecipeViewModelDidSuccessPostRecipeImages(self!)
             case .failure(let error):
-                self?.delegate?.didFailedPostRecipeImages(errorMessage: error.description())
+                self?.delegate?.postRecipeViewModelDidFailedPostRecipeImages(self!, with: error.description())
             }
         }
     }
@@ -68,7 +62,7 @@ extension PostRecipeViewModel {
 extension PostRecipeViewModel {
     func postRecipeImages(kikurageUserId: String, imageData: [Data?]) {
         guard let postedRecipeDocumentId = postedRecipeDocumentId else {
-            delegate?.didFailedPostRecipeImages(errorMessage: FirebaseAPIError.documentIdError.description())
+            delegate?.postRecipeViewModelDidFailedPostRecipeImages(self, with: FirebaseAPIError.documentIdError.description())
             return
         }
         let imageStoragePath = "\(Constants.FirestoreCollectionName.users)/\(kikurageUserId)/\(Constants.FirestoreCollectionName.recipes)/\(postedRecipeDocumentId)/images/"
@@ -77,7 +71,7 @@ extension PostRecipeViewModel {
             case .success(let imageStoraageFullPaths):
                 self?.postRecipeImages(kikurageUserId: kikurageUserId, firestoreDocumentId: postedRecipeDocumentId, imageStorageFullPaths: imageStoraageFullPaths)
             case .failure(let error):
-                self?.delegate?.didFailedPostRecipeImages(errorMessage: error.description())
+                self?.delegate?.postRecipeViewModelDidFailedPostRecipeImages(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
+++ b/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
@@ -9,8 +9,7 @@
 import UIKit
 
 protocol RecipeBaseViewDelegate: AnyObject {
-    /// 料理記録保存画面のボタンをタップした時の処理
-    func didTapPostRecipePageButton()
+    func recipeBaseViewDidTapPostRecipePageButton(_ recipeBaseView: RecipeBaseView)
 }
 
 class RecipeBaseView: UIView {
@@ -27,8 +26,8 @@ class RecipeBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapPostRecipePageButton(_ sender: Any) {
-        delegate?.didTapPostRecipePageButton()
+    @IBAction private func openRecipePost(_ sender: Any) {
+        delegate?.recipeBaseViewDidTapPostRecipePageButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Yn1-qf-8LL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Yn1-qf-8LL">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,8 +12,8 @@
         <!--Recipe View Controller-->
         <scene sceneID="yAG-CV-i13">
             <objects>
-                <viewController id="Yn1-qf-8LL" customClass="RecipeViewController" customModule="きくらげ君" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="uu3-0x-fob" customClass="RecipeBaseView" customModule="きくらげ君" customModuleProvider="target">
+                <viewController id="Yn1-qf-8LL" customClass="RecipeViewController" customModule="Kikurage" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="uu3-0x-fob" customClass="RecipeBaseView" customModule="Kikurage" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -31,7 +31,7 @@
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
                                 <connections>
-                                    <action selector="didTapPostRecipePageButton:" destination="uu3-0x-fob" eventType="touchUpInside" id="OnS-Vc-C1I"/>
+                                    <action selector="openRecipePost:" destination="uu3-0x-fob" eventType="touchUpInside" id="fYC-gf-7wu"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
@@ -68,7 +68,7 @@ extension RecipeViewController {
 // MARK: - RecipeBaseView Delegate
 
 extension RecipeViewController: RecipeBaseViewDelegate {
-    func didTapPostRecipePageButton() {
+    func recipeBaseViewDidTapPostRecipePageButton(_ recipeBaseView: RecipeBaseView) {
         guard let vc = R.storyboard.postRecipeViewController.instantiateInitialViewController() else { return }
         present(vc, animated: true, completion: nil)
     }
@@ -85,16 +85,16 @@ extension RecipeViewController: UITableViewDelegate {
 // MARK: - RecipeViewModel Delegate
 
 extension RecipeViewController: RecipeViewModelDelegate {
-    func didSuccessGetRecipes() {
+    func recipeViewModelDidSuccessGetRecipes(_ recipeViewModel: RecipeViewModel) {
         DispatchQueue.main.async {
             HUD.hide()
             self.baseView.tableView.refreshControl?.endRefreshing()
 
             self.baseView.tableView.reloadData()
-            self.baseView.noRecipeLabel.isHidden = !(self.viewModel.recipes.isEmpty)
+            self.baseView.noRecipeLabel.isHidden = !(recipeViewModel.recipes.isEmpty)
         }
     }
-    func didFailedGetRecipes(errorMessage: String) {
+    func recipeViewModelDidFailedGetRecipes(_ recipeViewModel: RecipeViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             self.baseView.tableView.refreshControl?.endRefreshing()

--- a/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
@@ -9,10 +9,8 @@
 import UIKit.UITableView
 
 protocol RecipeViewModelDelegate: AnyObject {
-    /// きくらげ料理記録の取得に成功した
-    func didSuccessGetRecipes()
-    /// きくらげ料理記録の取得に失敗した
-    func didFailedGetRecipes(errorMessage: String)
+    func recipeViewModelDidSuccessGetRecipes(_ recipeViewModel: RecipeViewModel)
+    func recipeViewModelDidFailedGetRecipes(_ recipeViewModel: RecipeViewModel, with errorMessage: String)
 }
 
 class RecipeViewModel: NSObject {
@@ -51,9 +49,9 @@ extension RecipeViewModel {
             case .success(let recipes):
                 self?.recipes = recipes
                 self?.sortRecipes()
-                self?.delegate?.didSuccessGetRecipes()
+                self?.delegate?.recipeViewModelDidSuccessGetRecipes(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetRecipes(errorMessage: error.description())
+                self?.delegate?.recipeViewModelDidFailedGetRecipes(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/BaseView/CalendarBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/BaseView/CalendarBaseView.swift
@@ -10,8 +10,7 @@ import UIKit
 import HorizonCalendar
 
 protocol CalendarBaseViewDelegate: AnyObject {
-    /// 閉じるボタンを押した時の処理
-    func didTapCloseButton()
+    func calendarBaseViewDidTapCloseButton(_ calendarBaseView: CalendarBaseView)
 }
 
 class CalendarBaseView: UIView {
@@ -27,8 +26,8 @@ class CalendarBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapCloseButton(_ sender: Any) {
-        delegate?.didTapCloseButton()
+    @IBAction private func close(_ sender: Any) {
+        delegate?.calendarBaseViewDidTapCloseButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.storyboard
@@ -28,7 +28,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="O0Y-Ez-wft">
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <connections>
-                                                <action selector="didTapCloseButton:" destination="uai-5v-WLU" id="sBI-Dz-957"/>
+                                                <action selector="close:" destination="uai-5v-WLU" id="9Tq-5f-uJf"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.swift
@@ -37,7 +37,7 @@ extension CalendarViewController {
 // MARK: - CalendarBaseView Delegate
 
 extension CalendarViewController: CalendarBaseViewDelegate {
-    func didTapCloseButton() {
+    func calendarBaseViewDidTapCloseButton(_ calendarBaseView: CalendarBaseView) {
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
@@ -45,10 +45,10 @@ extension CalendarViewController: CalendarBaseViewDelegate {
 // MARK: - CalendarViewModel Delegate
 
 extension CalendarViewController: CalendarViewModelDelegate {
-    func didSuccessGetKikurageUser() {
-        baseView.initCalendarView(cultivationStartDateComponents: viewModel.cultivationDateComponents, cultivationTerm: (viewModel.cultivationTerm ?? 0))
+    func calendarViewModelDidSuccessGetKikurageUser(_ calendarViewModel: CalendarViewModel) {
+        baseView.initCalendarView(cultivationStartDateComponents: calendarViewModel.cultivationDateComponents, cultivationTerm: (calendarViewModel.cultivationTerm ?? 0))
     }
-    func didFailedGetKikurageUser(errorMessage: String) {
+    func calendarViewModelDidFailedGetKikurageUser(_ calendarViewModel: CalendarViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewModel/CalendarViewModel.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewModel/CalendarViewModel.swift
@@ -9,11 +9,8 @@
 import Foundation
 
 protocol CalendarViewModelDelegate: AnyObject {
-    /// きくらげユーザーの取得に成功した
-    func didSuccessGetKikurageUser()
-    /// きくらげユーザーの取得に失敗しました
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageUser(errorMessage: String)
+    func calendarViewModelDidSuccessGetKikurageUser(_ calendarViewModel: CalendarViewModel)
+    func calendarViewModelDidFailedGetKikurageUser(_ calendarViewModel: CalendarViewModel, with errorMessage: String)
 }
 
 class CalendarViewModel {
@@ -45,7 +42,7 @@ extension CalendarViewModel {
         
         let startDate = calendar.startOfDay(for: kikurageUser?.cultivationStartDate ?? Date())
         let endDate = calendar.startOfDay(for: Date())
-        
+
         let components = calendar.dateComponents([.day], from: startDate, to: endDate)
         cultivationTerm = components.day
     }
@@ -63,9 +60,9 @@ extension CalendarViewModel {
                 self?.kikurageUser = kikurageUser
                 self?.saveDateComponents()
                 self?.calcCultivationTerm()
-                self?.delegate?.didSuccessGetKikurageUser()
+                self?.delegate?.calendarViewModelDidSuccessGetKikurageUser(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageUser(errorMessage: error.description())
+                self?.delegate?.calendarViewModelDidFailedGetKikurageUser(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/BaseView/GraphBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/BaseView/GraphBaseView.swift
@@ -15,8 +15,7 @@ enum GraphDataType {
 }
 
 protocol GraphBaseViewDelegate: AnyObject {
-    /// 閉じるボタンを押した時の処理
-    func didTapCloseButton()
+    func graphBaseViewDidTapCloseButton(_ graphBaseView: GraphBaseView)
 }
 
 class GraphBaseView: UIView {
@@ -40,8 +39,8 @@ class GraphBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTapCloseButton(_ sender: Any) {
-        delegate?.didTapCloseButton()
+    @IBAction private func close(_ sender: Any) {
+        delegate?.graphBaseViewDidTapCloseButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.storyboard
@@ -24,7 +24,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="9Ie-1Q-Syt">
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <connections>
-                                                <action selector="didTapCloseButton:" destination="rav-Yu-zgV" id="JV2-Yq-XdR"/>
+                                                <action selector="close:" destination="rav-Yu-zgV" id="QNP-Hq-fkr"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
@@ -43,7 +43,7 @@ extension GraphViewController {
 // MARK: - GraphBaseView Delegate
 
 extension GraphViewController: GraphBaseViewDelegate {
-    func didTapCloseButton() {
+    func graphBaseViewDidTapCloseButton() {
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
@@ -51,25 +51,25 @@ extension GraphViewController: GraphBaseViewDelegate {
 // MARK: - GraphViewModel Delegate
 
 extension GraphViewController: GraphViewModelDelegate {
-    func didSuccessGetKikurageStateGraph() {
+    func graphViewModelDidSuccessGetKikurageStateGraph(_ graphViewModel: GraphViewModel) {
         DispatchQueue.main.async {
             self.baseView.stopGraphActivityIndicators()
 
-            self.baseView.setLineChartView(datas: self.viewModel.humidityGraphDatas, graphDataType: .humidity)
-            self.baseView.setLineChartView(datas: self.viewModel.temperatureGraphDatas, graphDataType: .temperature)
+            self.baseView.setLineChartView(datas: graphViewModel.humidityGraphDatas, graphDataType: .humidity)
+            self.baseView.setLineChartView(datas: graphViewModel.temperatureGraphDatas, graphDataType: .temperature)
         }
     }
-    func didFailedGetKikurageStateGraph(errorMessage: String) {
+    func graphViewModelDidFailedGetKikurageStateGraph(_ graphViewModel: GraphViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             self.baseView.stopGraphActivityIndicators()
 
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }
     }
-    func didSuccessGetKikurageUser() {
+    func graphViewModelDidSuccessGetKikurageUser(_ graphViewModel: GraphViewModel) {
         loadKikurageStateGraph()
     }
-    func didFailedGetKikurageUser(errorMessage: String) {
+    func graphViewModelDidFailedGetKikurageUser(_ graphViewModel: GraphViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
@@ -43,7 +43,7 @@ extension GraphViewController {
 // MARK: - GraphBaseView Delegate
 
 extension GraphViewController: GraphBaseViewDelegate {
-    func graphBaseViewDidTapCloseButton() {
+    func graphBaseViewDidTapCloseButton(_ graphBaseView: GraphBaseView) {
         presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewModel/GraphViewModel.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewModel/GraphViewModel.swift
@@ -9,16 +9,10 @@
 import Foundation
 
 protocol GraphViewModelDelegate: AnyObject {
-    /// きくらげの状態グラフデータの取得に成功した
-    func didSuccessGetKikurageStateGraph()
-    /// きくらげの状態グラフデータの取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageStateGraph(errorMessage: String)
-    /// きくらげユーザーの取得に成功した
-    func didSuccessGetKikurageUser()
-    /// きくらげユーザーの取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageUser(errorMessage: String)
+    func graphViewModelDidSuccessGetKikurageStateGraph(_ graphViewModel: GraphViewModel)
+    func graphViewModelDidFailedGetKikurageStateGraph(_ graphViewModel: GraphViewModel, with errorMessage: String)
+    func graphViewModelDidSuccessGetKikurageUser(_ graphViewModel: GraphViewModel)
+    func graphViewModelDidFailedGetKikurageUser(_ graphViewModel: GraphViewModel, with errorMessage: String)
 }
 
 class GraphViewModel {
@@ -78,9 +72,9 @@ extension GraphViewModel {
                 self?.kikurageStateGraph = graphs
                 self?.setTemperatureGraphData()
                 self?.setHumidityGraphData()
-                self?.delegate?.didSuccessGetKikurageStateGraph()
+                self?.delegate?.graphViewModelDidSuccessGetKikurageStateGraph(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageStateGraph(errorMessage: error.description())
+                self?.delegate?.graphViewModelDidFailedGetKikurageStateGraph(self!, with: error.description())
             }
         }
     }
@@ -91,9 +85,9 @@ extension GraphViewModel {
             switch response {
             case .success(let kikurageUser):
                 self?.kikurageUser = kikurageUser
-                self?.delegate?.didSuccessGetKikurageUser()
+                self?.delegate?.graphViewModelDidSuccessGetKikurageUser(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageUser(errorMessage: error.description())
+                self?.delegate?.graphViewModelDidFailedGetKikurageUser(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/BaseView/SettingBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/BaseView/SettingBaseView.swift
@@ -9,9 +9,9 @@
 import UIKit
 
 protocol SettingBaseViewDelegate: AnyObject {
-    func didTappedEditButton()
-    func didTappedUserImageView()
-    func didTappedCloseButton()
+    func settingBaseViewDidTappedEditButton(_ settingBaseView: SettingBaseView)
+    func settingBaseViewDidTappedUserImageView(_ settingBaseView: SettingBaseView)
+    func settingBaseViewDidTappedCloseButton(_ settingBaseView: SettingBaseView)
 }
 
 class SettingBaseView: UIView {
@@ -29,14 +29,14 @@ class SettingBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTappedEditButton(_ sender: Any) {
-        delegate?.didTappedEditButton()
+    @IBAction private func edit(_ sender: Any) {
+        delegate?.settingBaseViewDidTappedEditButton(self)
     }
-    @IBAction private func didTappedUserImageView(_ sender: Any) {
-        delegate?.didTappedUserImageView()
+    @IBAction private func editUserImage(_ sender: Any) {
+        delegate?.settingBaseViewDidTappedUserImageView(self)
     }
-    @IBAction private func didTappedCloseButton(_ sender: Any) {
-        delegate?.didTappedCloseButton()
+    @IBAction private func close(_ sender: Any) {
+        delegate?.settingBaseViewDidTappedCloseButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.storyboard
@@ -25,7 +25,7 @@
                                         <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="10M-c2-k7n">
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <connections>
-                                                <action selector="didTappedCloseButton:" destination="5EZ-qb-Rvc" id="JBh-dl-od3"/>
+                                                <action selector="close:" destination="5EZ-qb-Rvc" id="XRe-DB-8aK"/>
                                             </connections>
                                         </barButtonItem>
                                     </navigationItem>
@@ -51,7 +51,7 @@
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain"/>
                                 <connections>
-                                    <action selector="didTappedEditButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="LBt-ZZ-P2k"/>
+                                    <action selector="edit:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="goT-zP-75p"/>
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Sw0-8n-Pej">
@@ -96,10 +96,9 @@
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-                <exit id="Qxc-Qc-uRj" userLabel="Exit" sceneMemberID="exit"/>
                 <tapGestureRecognizer id="qtH-26-XFZ">
                     <connections>
-                        <action selector="didTappedUserImageView:" destination="Qxc-Qc-uRj" id="SUw-3O-C0P"/>
+                        <action selector="editUserImage:" destination="5EZ-qb-Rvc" id="JCA-5O-J2e"/>
                     </connections>
                 </tapGestureRecognizer>
             </objects>

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.swift
@@ -36,13 +36,13 @@ extension SettingViewController {
 // MARK: - SettingBaseView Delegate
 
 extension SettingViewController: SettingBaseViewDelegate {
-    func didTappedUserImageView() {
+    func settingBaseViewDidTappedUserImageView(_ settingBaseView: SettingBaseView) {
         // FIXME: 写真アプリから写真を選んで円形にトリミング（CropViewController）してViewModelにあるKikurageUserを更新する
     }
-    func didTappedEditButton() {
+    func settingBaseViewDidTappedEditButton(_ settingBaseView: SettingBaseView) {
         // FIXME: ViewModelにあるkikurageUserを更新する処理を書く
     }
-    func didTappedCloseButton() {
+    func settingBaseViewDidTappedCloseButton(_ settingBaseView: SettingBaseView) {
         dismiss(animated: true, completion: nil)
     }
 }
@@ -50,12 +50,12 @@ extension SettingViewController: SettingBaseViewDelegate {
 // MARK: - SettingViewModel Delegate
 
 extension SettingViewController: SettingViewModelDelegate {
-    func didSuccessGetKikurageUser() {
+    func settingViewModelDidSuccessGetKikurageUser(_ settingViewModel: SettingViewModel) {
         DispatchQueue.main.async {
-            self.baseView.setKikurageName(name: self.viewModel.kikurageUser?.kikurageName)
+            self.baseView.setKikurageName(name: settingViewModel.kikurageUser?.kikurageName)
         }
     }
-    func didFailedGetKikurageUser(errorMessage: String) {
+    func settingViewModelDidFailedGetKikurageUser(_ settingViewModel: SettingViewModel, with errorMessage: String) {
         DispatchQueue.main.async {
             self.baseView.setKikurageName(name: nil)
         }

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewModel/SettingViewModel.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewModel/SettingViewModel.swift
@@ -9,11 +9,8 @@
 import Foundation
 
 protocol SettingViewModelDelegate: AnyObject {
-    /// きくらげユーザーの取得に成功した
-    func didSuccessGetKikurageUser()
-    /// きくらげユーザーの取得に失敗した
-    /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageUser(errorMessage: String)
+    func settingViewModelDidSuccessGetKikurageUser(_ settingViewModel: SettingViewModel)
+    func settingViewModelDidFailedGetKikurageUser(_ settingViewModel: SettingViewModel, with errorMessage: String)
 }
 
 class SettingViewModel {
@@ -36,9 +33,9 @@ extension SettingViewModel {
             switch response {
             case .success(let kikurageUser):
                 self?.kikurageUser = kikurageUser
-                self?.delegate?.didSuccessGetKikurageUser()
+                self?.delegate?.settingViewModelDidSuccessGetKikurageUser(self!)
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageUser(errorMessage: error.description())
+                self?.delegate?.settingViewModelDidFailedGetKikurageUser(self!, with: error.description())
             }
         }
     }

--- a/Kikurage/ScreenModule/Top/BaseView/TopBaseView.swift
+++ b/Kikurage/ScreenModule/Top/BaseView/TopBaseView.swift
@@ -9,10 +9,10 @@
 import UIKit
 
 protocol TopBaseViewDelegate: AnyObject {
-    func didTappedTermsButton()
-    func didTappedPrivacyPolicyButton()
-    func didTappedLoginButton()
-    func didTappedSignUpButton()
+    func topBaseViewDidTappedTermsButton(_ topBaseView: TopBaseView)
+    func topBaseViewDidTappedPrivacyPolicyButton(_ topBaseView: TopBaseView)
+    func topBaseViewDidTappedLoginButton(_ topBaseView: TopBaseView)
+    func topBaseViewDidTappedSignUpButton(_ topBaseView: TopBaseView)
 }
 
 class TopBaseView: UIView {
@@ -32,17 +32,17 @@ class TopBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func didTappedTermsButton(_ sender: Any) {
-        delegate?.didTappedTermsButton()
+    @IBAction private func openTerms(_ sender: Any) {
+        delegate?.topBaseViewDidTappedTermsButton(self)
     }
-    @IBAction private func didTappedPrivacyPolicyButton(_ sender: Any) {
-        delegate?.didTappedPrivacyPolicyButton()
+    @IBAction private func openPrivacyPolicy(_ sender: Any) {
+        delegate?.topBaseViewDidTappedPrivacyPolicyButton(self)
     }
-    @IBAction private func didTappedLoginButton(_ sender: Any) {
-        delegate?.didTappedLoginButton()
+    @IBAction private func login(_ sender: Any) {
+        delegate?.topBaseViewDidTappedLoginButton(self)
     }
-    @IBAction private func didTappedSignUpButton(_ sender: Any) {
-        delegate?.didTappedSignUpButton()
+    @IBAction private func signUp(_ sender: Any) {
+        delegate?.topBaseViewDidTappedSignUpButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Top/ViewController/TopViewController.storyboard
+++ b/Kikurage/ScreenModule/Top/ViewController/TopViewController.storyboard
@@ -35,7 +35,7 @@
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTappedLoginButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="9wM-U2-9E6"/>
+                                    <action selector="login:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="IS8-CZ-UCk"/>
                                 </connections>
                             </button>
                             <button opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FuL-mP-68c">
@@ -49,7 +49,7 @@
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                                 <connections>
-                                    <action selector="didTappedSignUpButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="xEP-ua-ekS"/>
+                                    <action selector="signUp:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="a3R-Me-d2X"/>
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="JBQ-z1-pFQ">
@@ -60,7 +60,7 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <state key="normal" title=""/>
                                         <connections>
-                                            <action selector="didTappedTermsButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="8ud-Vd-OIT"/>
+                                            <action selector="openTerms:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="lIS-ay-wwk"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WcK-7Q-gF3">
@@ -70,7 +70,7 @@
                                             <color key="titleColor" red="0.25882352941176467" green="0.25882352941176467" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
-                                            <action selector="didTappedPrivacyPolicyButton:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="IuX-zh-NLD"/>
+                                            <action selector="openPrivacyPolicy:" destination="5EZ-qb-Rvc" eventType="touchUpInside" id="HyE-zO-X2O"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Kikurage/ScreenModule/Top/ViewController/TopViewController.swift
+++ b/Kikurage/ScreenModule/Top/ViewController/TopViewController.swift
@@ -33,22 +33,22 @@ extension TopViewController {
 // MARK: - TopBaseView Delegate
 
 extension TopViewController: TopBaseViewDelegate {
-    func didTappedTermsButton() {
+    func topBaseViewDidTappedTermsButton(_ topBaseView: TopBaseView) {
         let urlString = AppConfig.shared.termsUrl
         transitionSafariViewController(urlString: urlString, onError: nil)
     }
 
-    func didTappedPrivacyPolicyButton() {
+    func topBaseViewDidTappedPrivacyPolicyButton(_ topBaseView: TopBaseView) {
         let urlString = AppConfig.shared.privacyPolicyUrl
         transitionSafariViewController(urlString: urlString, onError: nil)
     }
 
-    func didTappedLoginButton() {
+    func topBaseViewDidTappedLoginButton(_ topBaseView: TopBaseView) {
         guard let vc = R.storyboard.loginViewController.instantiateInitialViewController() else { return }
         navigationController?.pushViewController(vc, animated: true)
     }
 
-    func didTappedSignUpButton() {
+    func topBaseViewDidTappedSignUpButton(_ topBaseView: TopBaseView) {
         guard let vc = R.storyboard.signUpViewController.instantiateInitialViewController() else { return }
         navigationController?.pushViewController(vc, animated: true)
     }


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 改善

<br>

### 詳細

- BaseViewおよびViewModelにあるdelegateメソッドやactionメソッドの名前を修正
  - delegate：名前が衝突しないようにクラス名をメソッド名の先頭と引数につけた
  - action：何をするかという動詞のみメソッド名につけた


## テスト環境
<!-- 都度確認して変更すること -->
- 開発環境
  - MacOS BigSur version 11.4
  - Xcode version 13.0 (13A233)
  - Swift version unspecified
  - CocoaPods version 1.9.3
- テスト
  - 実機 iPhone SE 2nd iOS 13.5.1

## 再現手順
- 特になし<!-- バグの場合はここに再現できる手順を書く -->

## 期待値
- 特になし<!-- 文章 + 画像などを使って期待する仕様を記述する -->

## 補足
- 特になし<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
