### PR TITLE
【栽培記録詳細画面】写真が２つ以上ある場合はPageControlを表示するようにした

### DIFF
--- a/Kikurage/ScreenModule/CultivationDetail/BaseView/CultivationDetailBaseView.swift
+++ b/Kikurage/ScreenModule/CultivationDetail/BaseView/CultivationDetailBaseView.swift
@@ -17,6 +17,8 @@ class CultivationDetailBaseView: UIView {
     @IBOutlet private weak var viewDateLabel: UILabel!
     @IBOutlet private weak var memoTextView: UITextView!
 
+    @IBOutlet private weak var pageControl: UIPageControl!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         initUI()
@@ -44,6 +46,10 @@ extension CultivationDetailBaseView {
         iconImageView.layer.cornerRadius = iconImageView.frame.width / 2
         iconImageView.layer.borderWidth = 0.5
         iconImageView.layer.borderColor = UIColor.gray.cgColor
+
+        pageControl.currentPage = 0
+        pageControl.currentPageIndicatorTintColor = .gray
+        pageControl.pageIndicatorTintColor = .white
     }
     private func setCollectionView() {
         flowLayout.estimatedItemSize = .zero
@@ -63,5 +69,15 @@ extension CultivationDetailBaseView {
     func configCollectionView(delegate: UICollectionViewDelegate, dataSource: UICollectionViewDataSource) {
         collectionView.delegate = delegate
         collectionView.dataSource = dataSource
+    }
+    func configPageControl(imageCount: Int) {
+        if imageCount <= 1 {
+            pageControl.numberOfPages = 0
+        } else {
+            pageControl.numberOfPages = imageCount
+        }
+    }
+    func configPageControl(didChangedCurrentPage index: Int) {
+        pageControl.currentPage = index
     }
 }

--- a/Kikurage/ScreenModule/CultivationDetail/ViewController/CultivationDetailViewController.storyboard
+++ b/Kikurage/ScreenModule/CultivationDetail/ViewController/CultivationDetailViewController.storyboard
@@ -17,12 +17,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="観察メモ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gsd-rX-F29">
-                                <rect key="frame" x="80" y="389" width="319" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Zb1-Zv-3hg">
                                 <rect key="frame" x="0.0" y="44" width="414" height="320"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -37,43 +31,60 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hakase" translatesAutoresizingMaskIntoConstraints="NO" id="n91-0Q-WoP">
-                                <rect key="frame" x="15" y="389" width="50" height="50"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="Bf6-U9-lfJ"/>
-                                    <constraint firstAttribute="width" constant="50" id="E3Z-rt-qfp"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020/12/21" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Bz-V6-ViH">
-                                <rect key="frame" x="80" y="417" width="319" height="17"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="ENd-f8-4nu">
-                                <rect key="frame" x="15" y="459" width="384" height="388"/>
+                                <rect key="frame" x="15" y="490" width="384" height="357"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
+                            <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="h8j-vG-VH1">
+                                <rect key="frame" x="0.0" y="364" width="414" height="26"/>
+                            </pageControl>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Z9R-U1-ya0">
+                                <rect key="frame" x="15" y="415" width="384" height="50"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hakase" translatesAutoresizingMaskIntoConstraints="NO" id="n91-0Q-WoP">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="Bf6-U9-lfJ"/>
+                                            <constraint firstAttribute="width" constant="50" id="E3Z-rt-qfp"/>
+                                        </constraints>
+                                    </imageView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="cLL-f5-EHo">
+                                        <rect key="frame" x="65" y="0.0" width="319" height="50"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="観察メモ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gsd-rX-F29">
+                                                <rect key="frame" x="0.0" y="0.0" width="319" height="26"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020/12/21" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Bz-V6-ViH">
+                                                <rect key="frame" x="0.0" y="33" width="319" height="17"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="mou-yz-hH8"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="n91-0Q-WoP" firstAttribute="top" secondItem="Zb1-Zv-3hg" secondAttribute="bottom" constant="25" id="3gm-7s-oZ1"/>
-                            <constraint firstItem="mou-yz-hH8" firstAttribute="trailing" secondItem="2Bz-V6-ViH" secondAttribute="trailing" constant="15" id="4FV-4G-nxf"/>
+                            <constraint firstItem="ENd-f8-4nu" firstAttribute="top" secondItem="Z9R-U1-ya0" secondAttribute="bottom" constant="25" id="1do-QA-5ok"/>
+                            <constraint firstItem="h8j-vG-VH1" firstAttribute="top" secondItem="Zb1-Zv-3hg" secondAttribute="bottom" id="B0S-aY-RMv"/>
+                            <constraint firstItem="h8j-vG-VH1" firstAttribute="leading" secondItem="mou-yz-hH8" secondAttribute="leading" id="Dr7-eV-xIE"/>
                             <constraint firstItem="ENd-f8-4nu" firstAttribute="leading" secondItem="mou-yz-hH8" secondAttribute="leading" constant="15" id="FjM-Rj-fNW"/>
-                            <constraint firstItem="2Bz-V6-ViH" firstAttribute="top" secondItem="gsd-rX-F29" secondAttribute="bottom" constant="7" id="HrP-hB-NJv"/>
-                            <constraint firstItem="gsd-rX-F29" firstAttribute="leading" secondItem="n91-0Q-WoP" secondAttribute="trailing" constant="15" id="JC0-7l-Oh0"/>
-                            <constraint firstItem="n91-0Q-WoP" firstAttribute="leading" secondItem="mou-yz-hH8" secondAttribute="leading" constant="15" id="Kof-6x-UHD"/>
-                            <constraint firstItem="ENd-f8-4nu" firstAttribute="top" secondItem="n91-0Q-WoP" secondAttribute="bottom" constant="20" id="NTj-tv-DdQ"/>
-                            <constraint firstItem="2Bz-V6-ViH" firstAttribute="leading" secondItem="n91-0Q-WoP" secondAttribute="trailing" constant="15" id="YyI-Do-EVT"/>
+                            <constraint firstItem="mou-yz-hH8" firstAttribute="trailing" secondItem="Z9R-U1-ya0" secondAttribute="trailing" constant="15" id="YNx-sg-YBg"/>
                             <constraint firstItem="Zb1-Zv-3hg" firstAttribute="top" secondItem="mou-yz-hH8" secondAttribute="top" id="ZbU-U6-fuz"/>
-                            <constraint firstItem="mou-yz-hH8" firstAttribute="trailing" secondItem="gsd-rX-F29" secondAttribute="trailing" constant="15" id="fnY-nR-RJ2"/>
                             <constraint firstItem="mou-yz-hH8" firstAttribute="bottom" secondItem="ENd-f8-4nu" secondAttribute="bottom" constant="15" id="fou-1m-81M"/>
+                            <constraint firstItem="Z9R-U1-ya0" firstAttribute="top" secondItem="h8j-vG-VH1" secondAttribute="bottom" constant="25" id="g5T-vT-z2k"/>
                             <constraint firstItem="Zb1-Zv-3hg" firstAttribute="trailing" secondItem="mou-yz-hH8" secondAttribute="trailing" id="iDt-Bf-EYX"/>
-                            <constraint firstItem="gsd-rX-F29" firstAttribute="top" secondItem="Zb1-Zv-3hg" secondAttribute="bottom" constant="25" id="tv0-Fv-ffZ"/>
+                            <constraint firstItem="Z9R-U1-ya0" firstAttribute="leading" secondItem="mou-yz-hH8" secondAttribute="leading" constant="15" id="onO-72-vZV"/>
+                            <constraint firstItem="mou-yz-hH8" firstAttribute="trailing" secondItem="h8j-vG-VH1" secondAttribute="trailing" id="rdf-WM-wBg"/>
                             <constraint firstItem="Zb1-Zv-3hg" firstAttribute="leading" secondItem="mou-yz-hH8" secondAttribute="leading" id="uGJ-bg-Bh0"/>
                             <constraint firstItem="mou-yz-hH8" firstAttribute="trailing" secondItem="ENd-f8-4nu" secondAttribute="trailing" constant="15" id="uwY-ni-ubg"/>
                         </constraints>
@@ -83,6 +94,7 @@
                             <outlet property="iconImageView" destination="n91-0Q-WoP" id="9J4-0h-52Z"/>
                             <outlet property="memoTextView" destination="ENd-f8-4nu" id="nwZ-Dy-HTn"/>
                             <outlet property="memoTitleLabel" destination="gsd-rX-F29" id="TXr-WF-VOB"/>
+                            <outlet property="pageControl" destination="h8j-vG-VH1" id="O1R-Qe-MoO"/>
                             <outlet property="viewDateLabel" destination="2Bz-V6-ViH" id="6kR-6Z-s8B"/>
                         </connections>
                     </view>

--- a/Kikurage/ScreenModule/CultivationDetail/ViewController/CultivationDetailViewController.swift
+++ b/Kikurage/ScreenModule/CultivationDetail/ViewController/CultivationDetailViewController.swift
@@ -35,6 +35,7 @@ extension CultivationDetailViewController {
     }
     private func setUI() {
         baseView.setUI(cultivation: self.cultivation)
+        baseView.configPageControl(imageCount: self.cultivation.imageStoragePaths.count)
     }
 }
 
@@ -43,6 +44,11 @@ extension CultivationDetailViewController {
 extension CultivationDetailViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         // TODO: 画像拡大処理を書く
+    }
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        DispatchQueue.main.async {
+            self.baseView.configPageControl(didChangedCurrentPage: indexPath.row)
+        }
     }
 }
 

--- a/Kikurage/ScreenModule/CultivationDetail/ViewModel/CultivationDetailViewModel.swift
+++ b/Kikurage/ScreenModule/CultivationDetail/ViewModel/CultivationDetailViewModel.swift
@@ -10,7 +10,7 @@ import UIKit.UICollectionView
 
 class CultivationDetailViewModel: NSObject {
     /// きくらげ 栽培記録データ
-    var cultivation: KikurageCultivation
+    private(set) var cultivation: KikurageCultivation
 
     private let sectionNumber = 1
 


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
### 🔧 改善  


## 詳細

- page control追加
- VMの`cultivation`プロパティのアクセスレベルをprivateに変更


## テスト環境
<!-- 都度確認して変更すること -->
- 開発環境
  - MacOS BigSur version 11.4
  - Xcode version 13.0 (13A233)
  - Swift version unspecified
  - CocoaPods version 1.9.3
- テスト
  - 実機 iPhone SE 2nd iOS 13.5.1

## 確認したこと
- 写真をスクロールしてPageControlインジケータのカラーが変わること<!-- バグの場合はここに再現できる手順を書く -->

## 補足
- なし<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
