### PR TITLE
【栽培記録一覧画面】Rxを導入

### DIFF
--- a/Kikurage/Entity/Response/KikurageCultivation.swift
+++ b/Kikurage/Entity/Response/KikurageCultivation.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import UIKit
+import Foundation
 import Firebase
 
-internal typealias Cultivations = [(cultivation: KikurageCultivation, documentId: String)]
+internal typealias KikurageCultivationTuple = (cultivation: KikurageCultivation, documentId: String)
 
 struct KikurageCultivation: Codable {
     /// 栽培メモ

--- a/Kikurage/Entity/Response/KikurageCultivation.swift
+++ b/Kikurage/Entity/Response/KikurageCultivation.swift
@@ -9,6 +9,8 @@
 import UIKit
 import Firebase
 
+internal typealias Cultivations = [(cultivation: KikurageCultivation, documentId: String)]
+
 struct KikurageCultivation: Codable {
     /// 栽培メモ
     var memo: String = ""

--- a/Kikurage/Repository/CultivationRepository.swift
+++ b/Kikurage/Repository/CultivationRepository.swift
@@ -33,7 +33,7 @@ protocol CultivationRepositoryProtocol {
     /// - Parameters:
     ///   - kikurageUserId: ユーザーID
     ///   - completion: 投稿成功、失敗のハンドル
-    func getCultivations(kikurageUserId: String, completion: @escaping (Result<[(cultivation: KikurageCultivation, documentId: String)], ClientError>) -> Void)
+    func getCultivations(kikurageUserId: String, completion: @escaping (Result<Cultivations, ClientError>) -> Void)
 }
 class CultivationRepository: CultivationRepositoryProtocol {
     /// Storageへ保存するデータのメタデータ
@@ -84,7 +84,7 @@ extension CultivationRepository {
             }
         }
     }
-    func getCultivations(kikurageUserId: String, completion: @escaping (Result<[(cultivation: KikurageCultivation, documentId: String)], ClientError>) -> Void) {
+    func getCultivations(kikurageUserId: String, completion: @escaping (Result<Cultivations, ClientError>) -> Void) {
         let db = Firestore.firestore()
         let collectionReference = db.collection(Constants.FirestoreCollectionName.users).document(kikurageUserId).collection(Constants.FirestoreCollectionName.cultivations)
         collectionReference.getDocuments { snapshot, error in
@@ -97,7 +97,7 @@ extension CultivationRepository {
                 completion(.failure(ClientError.apiError(.readError)))
                 return
             }
-            var cultivations: [(cultivation: KikurageCultivation, documentId: String)] = []
+            var cultivations: Cultivations = []
             do {
                 for document in snapshot.documents {
                     let cultivation = try Firestore.Decoder().decode(KikurageCultivation.self, from: document.data())

--- a/Kikurage/Repository/CultivationRepository.swift
+++ b/Kikurage/Repository/CultivationRepository.swift
@@ -33,7 +33,7 @@ protocol CultivationRepositoryProtocol {
     /// - Parameters:
     ///   - kikurageUserId: ユーザーID
     ///   - completion: 投稿成功、失敗のハンドル
-    func getCultivations(kikurageUserId: String, completion: @escaping (Result<Cultivations, ClientError>) -> Void)
+    func getCultivations(kikurageUserId: String, completion: @escaping (Result<[KikurageCultivationTuple], ClientError>) -> Void)
 }
 class CultivationRepository: CultivationRepositoryProtocol {
     /// Storageへ保存するデータのメタデータ
@@ -84,7 +84,7 @@ extension CultivationRepository {
             }
         }
     }
-    func getCultivations(kikurageUserId: String, completion: @escaping (Result<Cultivations, ClientError>) -> Void) {
+    func getCultivations(kikurageUserId: String, completion: @escaping (Result<[KikurageCultivationTuple], ClientError>) -> Void) {
         let db = Firestore.firestore()
         let collectionReference = db.collection(Constants.FirestoreCollectionName.users).document(kikurageUserId).collection(Constants.FirestoreCollectionName.cultivations)
         collectionReference.getDocuments { snapshot, error in
@@ -97,7 +97,7 @@ extension CultivationRepository {
                 completion(.failure(ClientError.apiError(.readError)))
                 return
             }
-            var cultivations: Cultivations = []
+            var cultivations: [KikurageCultivationTuple] = []
             do {
                 for document in snapshot.documents {
                     let cultivation = try Firestore.Decoder().decode(KikurageCultivation.self, from: document.data())

--- a/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
+++ b/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
@@ -8,17 +8,11 @@
 
 import UIKit
 
-protocol CultivationBaseViewDelegate: AnyObject {
-    func cultivationBaseViewDidTapPostCultivationPageButton(_ cultivationBaseView: CultivationBaseView)
-}
-
 class CultivationBaseView: UIView {
-    @IBOutlet private weak var postPageButton: UIButton!
+    @IBOutlet private(set) weak var postPageButton: UIButton!
     @IBOutlet private(set) weak var collectionView: UICollectionView!
     @IBOutlet private weak var flowLayout: UICollectionViewFlowLayout!
     @IBOutlet private weak var noCultivationLabel: UILabel!
-
-    weak var delegate: CultivationBaseViewDelegate?
 
     // MARK: - Lifecycle
 
@@ -26,12 +20,6 @@ class CultivationBaseView: UIView {
         super.awakeFromNib()
         initUI()
         setCollectionView()
-    }
-
-    // MARK: - Action
-
-    @IBAction private func openCultivationPost(_ sender: Any) {
-        delegate?.cultivationBaseViewDidTapPostCultivationPageButton(self)
     }
 }
 
@@ -59,10 +47,6 @@ extension CultivationBaseView {
 extension CultivationBaseView {
     func setRefreshControlInCollectionView(_ refresh: UIRefreshControl) {
         collectionView.refreshControl = refresh
-    }
-    func configColletionView(delegate: UICollectionViewDelegate, dataSource: UICollectionViewDataSource) {
-        collectionView.delegate = delegate
-        collectionView.dataSource = dataSource
     }
     func noCultivationLabelIsHidden(_ isHidden: Bool) {
         noCultivationLabel.isHidden = isHidden

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
@@ -37,9 +37,6 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KeL-SW-wEN">
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
-                                <connections>
-                                    <action selector="openCultivationPost:" destination="JsX-gy-r0o" eventType="touchUpInside" id="q1I-8A-5h7"/>
-                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Jar-At-3Vx"/>

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
@@ -8,18 +8,22 @@
 
 import UIKit
 import PKHUD
+import RxSwift
 
 class CultivationViewController: UIViewController, UIViewControllerNavigatable {
     private var baseView: CultivationBaseView { self.view as! CultivationBaseView } // swiftlint:disable:this force_cast
     private var viewModel: CultivationViewModel!
 
+    private let disposeBag = RxSwift.DisposeBag()
+
     // MARK: - Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel = CultivationViewModel(cultivationRepository: CultivationRepository())
-        setNavigationItem()
+        self.viewModel = CultivationViewModel(cultivationRepository: CultivationRepository())
+
         setDelegateDataSource()
+        setNavigationItem()
         setNotificationCenter()
         setRefreshControl()
 
@@ -29,6 +33,10 @@ class CultivationViewController: UIViewController, UIViewControllerNavigatable {
             HUD.show(.progress)
             viewModel.loadCultivations(kikurageUserId: kikurageUserId)
         }
+
+        // RX
+        rxBaseView()
+        rxTransition()
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -49,56 +57,75 @@ extension CultivationViewController {
     private func setNavigationItem() {
         setNavigationBar(title: R.string.localizable.screen_cultivation_title())
     }
-    private func setDelegateDataSource() {
-        baseView.delegate = self
-        baseView.configColletionView(delegate: self, dataSource: viewModel)
-        viewModel.delegate = self
-    }
     private func setRefreshControl() {
         let refresh = UIRefreshControl()
         refresh.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         baseView.setRefreshControlInCollectionView(refresh)
+    }
+    private func setDelegateDataSource() {
+        baseView.collectionView.delegate = self
+    }
+}
+
+// MARK: - Rx
+
+extension CultivationViewController {
+    private func rxBaseView() {
+        viewModel.output.cultivations.bind(to: baseView.collectionView.rx.items) { collectionView, row, element in
+            let indexPath = IndexPath(index: row)
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: R.reuseIdentifier.cultivationCollectionViewCell, for: indexPath)! // swiftlint:disable:this force_unwrapping
+            cell.setUI(cultivation: element.cultivation)
+            return cell
+        }
+        .disposed(by: disposeBag)
+
+        viewModel.output.cultivations.subscribe(
+            onNext: { [weak self] cultivations in
+                DispatchQueue.main.async {
+                    HUD.hide()
+                    self?.baseView.collectionView.refreshControl?.endRefreshing()
+                    self?.baseView.collectionView.reloadData()
+                    self?.baseView.noCultivationLabelIsHidden(!cultivations.isEmpty)
+                }
+            },
+            onError: { error in
+                DispatchQueue.main.async {
+                    HUD.hide()
+                    self.baseView.collectionView.refreshControl?.endRefreshing()
+
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    UIAlertController.showAlert(style: .alert, viewController: self, title: error.description(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
+                }
+            }
+        )
+        .disposed(by: disposeBag)
+
+        baseView.collectionView.rx.itemSelected.subscribe(
+            onNext: { indexPath in
+                // TODO: セルをタップして詳細画面へ遷移させる処理を書く
+            }
+        )
+        .disposed(by: disposeBag)
+    }
+    private func rxTransition() {
+        baseView.postPageButton.rx.tap.asDriver()
+            .drive(
+            onNext: { [weak self] in
+                guard let vc = R.storyboard.postCultivationViewController.instantiateInitialViewController() else { return }
+                self?.present(vc, animated: true, completion: nil)
+            }
+        )
+        .disposed(by: disposeBag)
     }
 }
 
 // MARK: - Transition
 
 extension CultivationViewController {
-    private func transitionCultivationDetailPage(indexPath: IndexPath) {
+    private func transitionCultivationDetailPage(cultivation: KikurageCultivation) {
         guard let vc = R.storyboard.cultivationDetailViewController.instantiateInitialViewController() else { return }
-        vc.cultivation = viewModel.cultivations[indexPath.row].cultivation
+        vc.cultivation = cultivation
         navigationController?.pushViewController(vc, animated: true)
-    }
-}
-
-// MARK: - CultivationBaseView Delegate
-
-extension CultivationViewController: CultivationBaseViewDelegate {
-    func cultivationBaseViewDidTapPostCultivationPageButton(_ cultivationBaseView: CultivationBaseView) {
-        guard let vc = R.storyboard.postCultivationViewController.instantiateInitialViewController() else { return }
-        present(vc, animated: true, completion: nil)
-    }
-}
-
-// MARK: - CultivationViewModel Delegate
-
-extension CultivationViewController: CultivationViewModelDelegate {
-    func cultivationViewModelDidSuccessGetCultivations(_ cultivationViewModel: CultivationViewModel) {
-        DispatchQueue.main.async {
-            HUD.hide()
-            self.baseView.collectionView.refreshControl?.endRefreshing()
-
-            self.baseView.collectionView.reloadData()
-            self.baseView.noCultivationLabelIsHidden(!(cultivationViewModel.cultivations.isEmpty))
-        }
-    }
-    func cultivationViewModelDidFailedGetCultivations(_ cultivationViewModel: CultivationViewModel, with errorMessage: String) {
-        DispatchQueue.main.async {
-            HUD.hide()
-            self.baseView.collectionView.refreshControl?.endRefreshing()
-
-            UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
-        }
     }
 }
 
@@ -110,14 +137,6 @@ extension CultivationViewController: UICollectionViewDelegateFlowLayout {
         let cellWidth: CGFloat = baseView.bounds.width / 2 - horizontalSpace
         let cellHeight: CGFloat = cellWidth
         return CGSize(width: cellWidth, height: cellHeight)
-    }
-}
-
-// MARK: - UICollectionView Delegate
-
-extension CultivationViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        transitionCultivationDetailPage(indexPath: indexPath)
     }
 }
 

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
@@ -100,19 +100,27 @@ extension CultivationViewController {
         )
         .disposed(by: disposeBag)
 
-        baseView.collectionView.rx.itemSelected.subscribe(
-            onNext: { indexPath in
-                // TODO: セルをタップして詳細画面へ遷移させる処理を書く
-            }
-        )
-        .disposed(by: disposeBag)
+        baseView.collectionView.rx.itemSelected
+            .bind(to: viewModel.input.itemSelected)
+            .disposed(by: disposeBag)
     }
     private func rxTransition() {
         baseView.postPageButton.rx.tap.asDriver()
             .drive(
             onNext: { [weak self] in
+                Logger.debug("\(Thread.main)")
                 guard let vc = R.storyboard.postCultivationViewController.instantiateInitialViewController() else { return }
                 self?.present(vc, animated: true, completion: nil)
+            }
+        )
+        .disposed(by: disposeBag)
+
+        viewModel.output.cultivation.subscribe(
+            onNext: { [weak self] cultivation in
+                Logger.debug("\(Thread.main)")
+                guard let vc = R.storyboard.cultivationDetailViewController.instantiateInitialViewController() else { return }
+                vc.cultivation = cultivation.cultivation
+                self?.navigationController?.pushViewController(vc, animated: true)
             }
         )
         .disposed(by: disposeBag)

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -59,7 +59,6 @@ extension CultivationViewModel {
             switch response {
             case .success(let cultivations):
                 Logger.verbose("\(cultivations)")
-                self?.cultivationCount = cultivations.count
                 // TODO: 降順にソートさせる
                 self?.subject.onNext(cultivations)
             case .failure(let error):

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -30,7 +30,6 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
     var output: CultivationViewModelOutput { self }
 
     var cultivations: Observable<[(cultivation: KikurageCultivation, documentId: String)]> { subject.asObservable() }
-    private var cultivationCount: Int = 0
 
     init(cultivationRepository: CultivationRepositoryProtocol) {
         self.cultivationRepository = cultivationRepository

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -23,14 +23,14 @@ protocol CultivationViewModelType {
 
 class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput, CultivationViewModelOutput {
     private let cultivationRepository: CultivationRepositoryProtocol
-    private let sectionNumber = 1
-    
+
     private let subject = PublishSubject<[(cultivation: KikurageCultivation, documentId: String)]>()
-    
+
     var input: CultivationViewModelInput { self }
     var output: CultivationViewModelOutput { self }
-    
+
     var cultivations: Observable<[(cultivation: KikurageCultivation, documentId: String)]> { subject.asObservable() }
+    private var cultivationCount: Int = 0
 
     init(cultivationRepository: CultivationRepositoryProtocol) {
         self.cultivationRepository = cultivationRepository
@@ -60,6 +60,7 @@ extension CultivationViewModel {
             switch response {
             case .success(let cultivations):
                 Logger.verbose("\(cultivations)")
+                self?.cultivationCount = cultivations.count
                 // TODO: 降順にソートさせる
                 self?.subject.onNext(cultivations)
             case .failure(let error):
@@ -69,16 +70,3 @@ extension CultivationViewModel {
         }
     }
 }
-
-// MARK: - CollectionView DataSource Method
-// TODO:
-/*
-extension CultivationViewModel: UICollectionViewDataSource
-    func numberOfSections(in collectionView: UICollectionView) -> Int {
-        sectionNumber
-    }
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        cultivations.count
-    }
-}
-*/

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -39,14 +39,12 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
 // MARK: - Config
 
 extension CultivationViewModel {
-    private func sortCultivations() {
-        /* For Not Observable object
-        cultivations.sort { cultivation1, cultivation2 -> Bool in
+    private func sortCultivations(cultivations: [(cultivation: KikurageCultivation, documentId: String)]) -> [(cultivation: KikurageCultivation, documentId: String)] {
+        cultivations.sorted { cultivation1, cultivation2 -> Bool in
             guard let cultivationDate1 = DateHelper.formatToDate(dateString: cultivation1.cultivation.viewDate) else { return false }
             guard let cultivationDate2 = DateHelper.formatToDate(dateString: cultivation2.cultivation.viewDate) else { return false }
             return cultivationDate1 > cultivationDate2
         }
-        */
     }
 }
 
@@ -56,14 +54,18 @@ extension CultivationViewModel {
     /// きくらげ栽培記録を読み込む
     func loadCultivations(kikurageUserId: String) {
         cultivationRepository.getCultivations(kikurageUserId: kikurageUserId) { [weak self] response in
+            guard let `self` = self else {
+                self?.subject.onError(ClientError.unknown)
+                return
+            }
             switch response {
             case .success(let cultivations):
                 Logger.verbose("\(cultivations)")
-                // TODO: 降順にソートさせる
-                self?.subject.onNext(cultivations)
+                let cultivations = self.sortCultivations(cultivations: cultivations)
+                self.subject.onNext(cultivations)
             case .failure(let error):
                 Logger.verbose(error.localizedDescription)
-                self?.subject.onError(error)
+                self.subject.onError(error)
             }
         }
     }

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -13,7 +13,7 @@ import RxSwift
 protocol CultivationViewModelInput {}
 
 protocol CultivationViewModelOutput {
-    var cultivations: Observable<[(cultivation: KikurageCultivation, documentId: String)]> { get }
+    var cultivations: Observable<Cultivations> { get }
 }
 
 protocol CultivationViewModelType {
@@ -24,12 +24,12 @@ protocol CultivationViewModelType {
 class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput, CultivationViewModelOutput {
     private let cultivationRepository: CultivationRepositoryProtocol
 
-    private let subject = PublishSubject<[(cultivation: KikurageCultivation, documentId: String)]>()
+    private let subject = PublishSubject<Cultivations>()
 
     var input: CultivationViewModelInput { self }
     var output: CultivationViewModelOutput { self }
 
-    var cultivations: Observable<[(cultivation: KikurageCultivation, documentId: String)]> { subject.asObservable() }
+    var cultivations: Observable<Cultivations> { subject.asObservable() }
 
     init(cultivationRepository: CultivationRepositoryProtocol) {
         self.cultivationRepository = cultivationRepository
@@ -39,7 +39,7 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
 // MARK: - Config
 
 extension CultivationViewModel {
-    private func sortCultivations(cultivations: [(cultivation: KikurageCultivation, documentId: String)]) -> [(cultivation: KikurageCultivation, documentId: String)] {
+    private func sortCultivations(cultivations: Cultivations) -> Cultivations {
         cultivations.sorted { cultivation1, cultivation2 -> Bool in
             guard let cultivationDate1 = DateHelper.formatToDate(dateString: cultivation1.cultivation.viewDate) else { return false }
             guard let cultivationDate2 = DateHelper.formatToDate(dateString: cultivation2.cultivation.viewDate) else { return false }


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
### 🔧 改善  
### 📱 その他  

## 詳細

- `(cultivation: KikurageCultivation, documentId: String)`をtypealiasでまとめた
- VC-VMをRx化した
  - cultivationのイベント通知
  - セルタップ時の画面遷移
  - 投稿ボタンタップ時の画面遷移
  - collection view datasource廃止
  - VM、BaseViewのdelegate廃止

## テスト環境
<!-- 都度確認して変更すること -->
- 開発環境
  - MacOS BigSur version 11.4
  - Xcode version 13.0 (13A233)
  - Swift version unspecified
  - CocoaPods version 1.9.3
- テスト
  - 実機 iPhone 11 Pro iOS 15.1

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く -->
- 画面が表示されること
  - 初回画面立ち上げ
  - リフレッシュ
  - 栽培記録投稿後の更新
- セルタップ・投稿ボタンタップ時に画面遷移されること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- なし
