### PR TITLE
【栽培記録一覧画面】Rxを導入

### DIFF
--- a/Kikurage/Entity/Response/KikurageRecipe.swift
+++ b/Kikurage/Entity/Response/KikurageRecipe.swift
@@ -9,6 +9,8 @@
 import UIKit
 import Firebase
 
+typealias KikurageRecipeTuple = (recipe: KikurageRecipe, documentId: String)
+
 struct KikurageRecipe: Codable {
     /// 料理名
     var name: String = ""

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -45,10 +45,10 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
 
         // for selected collection view item
         let _cultivation = PublishRelay<KikurageCultivationTuple>()
-        self.cultivation = _cultivation.asObservable()
+        cultivation = _cultivation.asObservable()
 
         let _itemSelected = PublishRelay<IndexPath>()
-        self.itemSelected = AnyObserver<IndexPath> { event in
+        itemSelected = AnyObserver<IndexPath> { event in
             guard let indexPath = event.element else {
                 return
             }

--- a/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
+++ b/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
@@ -8,26 +8,15 @@
 
 import UIKit
 
-protocol RecipeBaseViewDelegate: AnyObject {
-    func recipeBaseViewDidTapPostRecipePageButton(_ recipeBaseView: RecipeBaseView)
-}
-
 class RecipeBaseView: UIView {
     @IBOutlet private(set) weak var tableView: UITableView!
     @IBOutlet private weak var noRecipeLabel: UILabel!
-
-    weak var delegate: RecipeBaseViewDelegate?
+    @IBOutlet private(set) weak var postPageButton: UIButton!
 
     override func awakeFromNib() {
         super.awakeFromNib()
         initUI()
         setTableView()
-    }
-
-    // MARK: - Action
-
-    @IBAction private func openRecipePost(_ sender: Any) {
-        delegate?.recipeBaseViewDidTapPostRecipePageButton(self)
     }
 }
 

--- a/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
+++ b/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
@@ -47,9 +47,8 @@ extension RecipeBaseView {
     func setRefreshControlInTableView(_ refresh: UIRefreshControl) {
         tableView.refreshControl = refresh
     }
-    func configTableView(delegate: UITableViewDelegate, dataSorce: UITableViewDataSource) {
+    func configTableView(delegate: UITableViewDelegate) {
         tableView.delegate = delegate
-        tableView.dataSource = dataSorce
     }
     func noRecipeLabelIsHidden(_ isHidden: Bool) {
         noRecipeLabel.isHidden = isHidden

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
@@ -30,9 +30,6 @@
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3g-dt-07M">
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
-                                <connections>
-                                    <action selector="openRecipePost:" destination="uu3-0x-fob" eventType="touchUpInside" id="fYC-gf-7wu"/>
-                                </connections>
                             </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="49h-m6-Xnv"/>
@@ -51,6 +48,7 @@
                         </constraints>
                         <connections>
                             <outlet property="noRecipeLabel" destination="2F5-2R-J3a" id="mUU-2N-ldh"/>
+                            <outlet property="postPageButton" destination="q3g-dt-07M" id="wYH-jc-r9o"/>
                             <outlet property="tableView" destination="x1J-99-6qg" id="7qg-4c-geG"/>
                         </connections>
                     </view>

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
@@ -36,6 +36,7 @@ class RecipeViewController: UIViewController, UIViewControllerNavigatable {
         }
 
         // Rx
+        rxBaseView()
         rxTransition()
     }
     override func viewWillAppear(_ animated: Bool) {
@@ -58,8 +59,7 @@ extension RecipeViewController {
         setNavigationBar(title: R.string.localizable.screen_recipe_title())
     }
     private func setDelegateDataSource() {
-        baseView.configTableView(delegate: self, dataSorce: viewModel)
-        viewModel.delegate = self
+        baseView.configTableView(delegate: self)
     }
     private func setRefreshControl() {
         let refresh = UIRefreshControl()
@@ -72,6 +72,35 @@ extension RecipeViewController {
 
 extension RecipeViewController {
     private func rxBaseView() {
+        viewModel.output.recipes.bind(to: baseView.tableView.rx.items) { tableview, row, element in
+            let indexPath = NSIndexPath(row: row, section: 0) as IndexPath
+            let cell = tableview.dequeueReusableCell(withIdentifier: R.reuseIdentifier.recipeTableViewCell, for: indexPath)! // swiftlint:disable:this force_unwrapping
+            cell.setUI(recipe: element.recipe)
+            return cell
+        }
+        .disposed(by: diposeBag)
+
+        viewModel.output.recipes.subscribe(
+            onNext: { [weak self] recipes in
+                DispatchQueue.main.async {
+                    HUD.hide()
+                    self?.baseView.tableView.refreshControl?.endRefreshing()
+                    self?.baseView.tableView.reloadData()
+                    self?.baseView.noRecipeLabelIsHidden(!recipes.isEmpty)
+                }
+            }, onError: { error in
+                DispatchQueue.main.async {
+                    HUD.hide()
+                    self.baseView.tableView.refreshControl?.endRefreshing()
+
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    UIAlertController.showAlert(style: .alert, viewController: self, title: error.description(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
+                }
+            }
+        )
+        .disposed(by: diposeBag)
+        
+        // MEMO: item on table view selected（nothing）
     }
     private func rxTransition() {
         baseView.postPageButton.rx.tap.asDriver()
@@ -82,6 +111,8 @@ extension RecipeViewController {
                 }
             )
             .disposed(by: diposeBag)
+        
+        // MEMO: subscrive to selected item on table view（nothing）
     }
 }
 
@@ -90,28 +121,6 @@ extension RecipeViewController {
 extension RecipeViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         cellHeight
-    }
-}
-
-// MARK: - RecipeViewModel Delegate
-
-extension RecipeViewController: RecipeViewModelDelegate {
-    func recipeViewModelDidSuccessGetRecipes(_ recipeViewModel: RecipeViewModel) {
-        DispatchQueue.main.async {
-            HUD.hide()
-            self.baseView.tableView.refreshControl?.endRefreshing()
-
-            self.baseView.tableView.reloadData()
-            self.baseView.noRecipeLabelIsHidden(!(recipeViewModel.recipes.isEmpty))
-        }
-    }
-    func recipeViewModelDidFailedGetRecipes(_ recipeViewModel: RecipeViewModel, with errorMessage: String) {
-        DispatchQueue.main.async {
-            HUD.hide()
-            self.baseView.tableView.refreshControl?.endRefreshing()
-
-            UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
-        }
     }
 }
 

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
@@ -9,11 +9,13 @@
 import UIKit
 import SafariServices
 import PKHUD
+import RxSwift
 
 class RecipeViewController: UIViewController, UIViewControllerNavigatable {
     private var baseView: RecipeBaseView { self.view as! RecipeBaseView } // swiftlint:disable:this force_cast
     private var viewModel: RecipeViewModel!
 
+    private let diposeBag = RxSwift.DisposeBag()
     private let cellHeight: CGFloat = 160.0
 
     // MARK: - Lifecycle
@@ -32,6 +34,9 @@ class RecipeViewController: UIViewController, UIViewControllerNavigatable {
             HUD.show(.progress)
             viewModel.loadRecipes(kikurageUserId: kikurageUserId)
         }
+
+        // Rx
+        rxTransition()
     }
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -53,7 +58,6 @@ extension RecipeViewController {
         setNavigationBar(title: R.string.localizable.screen_recipe_title())
     }
     private func setDelegateDataSource() {
-        baseView.delegate = self
         baseView.configTableView(delegate: self, dataSorce: viewModel)
         viewModel.delegate = self
     }
@@ -64,12 +68,20 @@ extension RecipeViewController {
     }
 }
 
-// MARK: - RecipeBaseView Delegate
+// MARK: - Rx
 
-extension RecipeViewController: RecipeBaseViewDelegate {
-    func recipeBaseViewDidTapPostRecipePageButton(_ recipeBaseView: RecipeBaseView) {
-        guard let vc = R.storyboard.postRecipeViewController.instantiateInitialViewController() else { return }
-        present(vc, animated: true, completion: nil)
+extension RecipeViewController {
+    private func rxBaseView() {
+    }
+    private func rxTransition() {
+        baseView.postPageButton.rx.tap.asDriver()
+            .drive(
+                onNext: { [weak self] in
+                    guard let vc = R.storyboard.postRecipeViewController.instantiateInitialViewController() else { return }
+                    self?.present(vc, animated: true, completion: nil)
+                }
+            )
+            .disposed(by: diposeBag)
     }
 }
 

--- a/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
@@ -7,31 +7,70 @@
 //
 
 import UIKit.UITableView
+import RxSwift
+import RxRelay
 
-protocol RecipeViewModelDelegate: AnyObject {
-    func recipeViewModelDidSuccessGetRecipes(_ recipeViewModel: RecipeViewModel)
-    func recipeViewModelDidFailedGetRecipes(_ recipeViewModel: RecipeViewModel, with errorMessage: String)
+protocol RecipeViewModelInput {
+    var itemSelected: AnyObserver<IndexPath> { get }
 }
 
-class RecipeViewModel: NSObject {
+protocol RecipeViewModelOutput {
+    var recipes: Observable<[KikurageRecipeTuple]> { get }
+    var recipe: Observable<KikurageRecipeTuple> { get }
+}
+
+protocol RecipeViewModelType {
+    var input: RecipeViewModelInput { get }
+    var output: RecipeViewModelOutput { get }
+}
+
+class RecipeViewModel: RecipeViewModelType, RecipeViewModelInput, RecipeViewModelOutput {
     private let recipeRepository: RecipeRepositoryProtocol
 
-    weak var delegate: RecipeViewModelDelegate?
-    ///　きくらげ料理データ
-    var recipes: [(recipe: KikurageRecipe, documentId: String)] = []
+    private let disposeBag = RxSwift.DisposeBag()
+    private let subject = PublishSubject<[KikurageRecipeTuple]>()
 
-    private let sectionNumber = 1
+    var input: RecipeViewModelInput { self }
+    var output: RecipeViewModelOutput { self }
+
+    var itemSelected: AnyObserver<IndexPath>
+
+    var recipes: Observable<[KikurageRecipeTuple]> { subject.asObservable() }
+    var recipe: Observable<KikurageRecipeTuple>
 
     init(recipeRepository: RecipeRepositoryProtocol) {
         self.recipeRepository = recipeRepository
+
+        // for selected table view item
+        let _recipe = PublishRelay<KikurageRecipeTuple>()
+        recipe = _recipe.asObservable()
+
+        let _itemSelected = PublishRelay<IndexPath>()
+        itemSelected = AnyObserver<IndexPath> { event in
+            guard let indexPath = event.element else {
+                return
+            }
+            _itemSelected.accept(indexPath)
+        }
+
+        _itemSelected
+            .withLatestFrom(recipes) { ($0.row, $1) }
+            .flatMap { index, recipes -> Observable<KikurageRecipeTuple> in
+                guard index < recipes.count else {
+                    return .empty()
+                }
+                return .just(recipes[index])
+            }
+            .bind(to: _recipe)
+            .disposed(by: disposeBag)
     }
 }
 
 // MARK: - Data Setting
 
 extension RecipeViewModel {
-    private func sortRecipes() {
-        recipes.sort { recipe1, recipe2 -> Bool in
+    private func sortRecipes(recipes: [KikurageRecipeTuple]) -> [KikurageRecipeTuple] {
+        recipes.sorted { recipe1, recipe2 -> Bool in
             guard let recipeDate1 = DateHelper.formatToDate(dateString: recipe1.recipe.cookDate) else { return false }
             guard let recipeDate2 = DateHelper.formatToDate(dateString: recipe2.recipe.cookDate) else { return false }
             return recipeDate1 > recipeDate2
@@ -45,30 +84,18 @@ extension RecipeViewModel {
     /// きくらげ料理記録を読み込む
     func loadRecipes(kikurageUserId: String) {
         recipeRepository.getRecipes(kikurageUserId: kikurageUserId) { [weak self] response in
+            guard let `self` = self else {
+                self?.subject.onError(ClientError.unknown)
+                return
+            }
             switch response {
             case .success(let recipes):
-                self?.recipes = recipes
-                self?.sortRecipes()
-                self?.delegate?.recipeViewModelDidSuccessGetRecipes(self!)
+                let recipes = self.sortRecipes(recipes: recipes)
+                self.subject.onNext(recipes)
             case .failure(let error):
-                self?.delegate?.recipeViewModelDidFailedGetRecipes(self!, with: error.description())
+                Logger.verbose(error.localizedDescription)
+                self.subject.onError(error)
             }
         }
-    }
-}
-
-// MARK: - UITableView DataSource
-
-extension RecipeViewModel: UITableViewDataSource {
-    func numberOfSections(in tableView: UITableView) -> Int {
-        sectionNumber
-    }
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        recipes.count
-    }
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: R.reuseIdentifier.recipeTableViewCell, for: indexPath)! // swiftlint:disable:this force_unwrapping
-        cell.setUI(recipe: recipes[indexPath.row].recipe)
-        return cell
     }
 }


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
### 🔧 改善  
### 📱 その他  


## 詳細

- VC-VMをRx化した
  - recipe更新のイベント通知
  - 投稿ボタンタップ時の画面遷移
  - table view datasorce廃止
  - VM、BaseViewのdelegate廃止

## テスト環境
<!-- 都度確認して変更すること -->
- 開発環境
  - MacOS BigSur version 11.4
  - Xcode version 13.0 (13A233)
  - Swift version unspecified
  - CocoaPods version 1.9.3
- テスト
  - 実機 iPhone 11 Pro iOS 15.1

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く -->
- 料理記録一覧が正常に表示されること
- 投稿ボタンをタップして投稿画面が開くこと

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- なし
