### PR TITLE
Rxを使ったAPIのエラーハンドリングを修正

### DIFF
--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
@@ -87,13 +87,16 @@ extension CultivationViewController {
                     self?.baseView.collectionView.reloadData()
                     self?.baseView.noCultivationLabelIsHidden(!cultivations.isEmpty)
                 }
-            },
-            onError: { error in
+            }
+        )
+        .disposed(by: disposeBag)
+
+        viewModel.output.error.subscribe(
+            onNext: { [weak self] error in
+                guard let `self` = self else { return }
                 DispatchQueue.main.async {
                     HUD.hide()
                     self.baseView.collectionView.refreshControl?.endRefreshing()
-
-                    let error = error as! ClientError // swiftlint:disable:this force_cast
                     UIAlertController.showAlert(style: .alert, viewController: self, title: error.description(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
                 }
             }

--- a/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewModel/CultivationViewModel.swift
@@ -19,6 +19,7 @@ protocol CultivationViewModelInput {
 protocol CultivationViewModelOutput {
     var cultivations: Observable<[KikurageCultivationTuple]> { get }
     var cultivation: Observable<KikurageCultivationTuple> { get }
+    var error: Observable<ClientError> { get }
 }
 
 protocol CultivationViewModelType {
@@ -31,6 +32,7 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
 
     private let disposeBag = RxSwift.DisposeBag()
     private let subject = PublishSubject<[KikurageCultivationTuple]>()
+    private let errorSubject = PublishSubject<ClientError>()
 
     var input: CultivationViewModelInput { self }
     var output: CultivationViewModelOutput { self }
@@ -39,6 +41,7 @@ class CultivationViewModel: CultivationViewModelType, CultivationViewModelInput,
 
     var cultivations: Observable<[KikurageCultivationTuple]> { subject.asObservable() }
     let cultivation: Observable<KikurageCultivationTuple>
+    var error: Observable<ClientError> { errorSubject.asObserver() }
 
     init(cultivationRepository: CultivationRepositoryProtocol) {
         self.cultivationRepository = cultivationRepository
@@ -94,7 +97,8 @@ extension CultivationViewModel {
                     self.subject.onNext(cultivations)
                 },
                 onFailure: { [weak self] error in
-                    self?.subject.onError(error)
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    self?.errorSubject.onNext(error)
                 }
             )
             .disposed(by: disposeBag)

--- a/Kikurage/ScreenModule/Home/ViewController/HomeViewController.swift
+++ b/Kikurage/ScreenModule/Home/ViewController/HomeViewController.swift
@@ -88,9 +88,12 @@ extension HomeViewController {
         viewModel.output.kikurageState.subscribe(
             onNext: { [weak self] kikurageState in
                 self?.baseView.setKikurageStateUI(kikurageState: kikurageState)
-            },
-            onError: { [weak self] error in
-                guard let error = error as? ClientError else { return }
+            }
+        )
+        .disposed(by: disposeBag)
+
+        viewModel.output.error.subscribe(
+            onNext: { [weak self] error in
                 self?.onFailedLoadingKikurageState(errorMessage: error.description())
             }
         )

--- a/Kikurage/ScreenModule/Home/ViewModel/HomeViewModel.swift
+++ b/Kikurage/ScreenModule/Home/ViewModel/HomeViewModel.swift
@@ -15,6 +15,7 @@ protocol HomeViewModelInput {
 
 protocol HomeViewModelOutput {
     var kikurageState: Observable<KikurageState> { get }
+    var error: Observable<ClientError> { get }
 }
 
 protocol HomeViewModelType {
@@ -27,6 +28,7 @@ class HomeViewModel: HomeViewModelType, HomeViewModelInput, HomeViewModelOutput 
     private let kikurageStateListenerRepository: KikurageStateListenerRepositoryProtocol
 
     private let subject = PublishSubject<KikurageState>()
+    private let errorSubject = PublishSubject<ClientError>()
     private let disposeBag = DisposeBag()
 
     var input: HomeViewModelInput { self }
@@ -34,6 +36,7 @@ class HomeViewModel: HomeViewModelType, HomeViewModelInput, HomeViewModelOutput 
 
     var kikurageUser: KikurageUser
     var kikurageState: Observable<KikurageState> { subject.asObservable() }
+    var error: Observable<ClientError> { errorSubject.asObservable() }
 
     init(kikurageUser: KikurageUser, kikurageStateRepository: KikurageStateRepositoryProtocol, kikurageStateListenerRepository: KikurageStateListenerRepositoryProtocol) {
         self.kikurageUser = kikurageUser
@@ -65,7 +68,8 @@ extension HomeViewModel {
                     self?.subject.onNext(kikurageState)
                 },
                 onFailure: { [weak self] error in
-                    self?.subject.onError(error)
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    self?.errorSubject.onNext(error)
                 }
             )
             .disposed(by: disposeBag)
@@ -78,7 +82,8 @@ extension HomeViewModel {
                     self?.subject.onNext(kikurageState)
                 },
                 onError: { [weak self] error in
-                    self?.subject.onError(error)
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    self?.errorSubject.onNext(error)
                 }
             )
             .disposed(by: disposeBag)

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
@@ -88,12 +88,16 @@ extension RecipeViewController {
                     self?.baseView.tableView.reloadData()
                     self?.baseView.noRecipeLabelIsHidden(!recipes.isEmpty)
                 }
-            }, onError: { error in
+            }
+        )
+        .disposed(by: diposeBag)
+        
+        viewModel.output.error.subscribe(
+            onNext: { [weak self] error in
                 DispatchQueue.main.async {
                     HUD.hide()
+                    guard let `self` = self else { return }
                     self.baseView.tableView.refreshControl?.endRefreshing()
-
-                    let error = error as! ClientError // swiftlint:disable:this force_cast
                     UIAlertController.showAlert(style: .alert, viewController: self, title: error.description(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
                 }
             }

--- a/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewModel/RecipeViewModel.swift
@@ -17,6 +17,7 @@ protocol RecipeViewModelInput {
 protocol RecipeViewModelOutput {
     var recipes: Observable<[KikurageRecipeTuple]> { get }
     var recipe: Observable<KikurageRecipeTuple> { get }
+    var error: Observable<ClientError> { get }
 }
 
 protocol RecipeViewModelType {
@@ -29,6 +30,7 @@ class RecipeViewModel: RecipeViewModelType, RecipeViewModelInput, RecipeViewMode
 
     private let disposeBag = RxSwift.DisposeBag()
     private let subject = PublishSubject<[KikurageRecipeTuple]>()
+    private let errorSubject = PublishSubject<ClientError>()
 
     var input: RecipeViewModelInput { self }
     var output: RecipeViewModelOutput { self }
@@ -37,6 +39,7 @@ class RecipeViewModel: RecipeViewModelType, RecipeViewModelInput, RecipeViewMode
 
     var recipes: Observable<[KikurageRecipeTuple]> { subject.asObservable() }
     var recipe: Observable<KikurageRecipeTuple>
+    var error: Observable<ClientError> { errorSubject.asObserver() }
 
     init(recipeRepository: RecipeRepositoryProtocol) {
         self.recipeRepository = recipeRepository
@@ -92,7 +95,8 @@ extension RecipeViewModel {
                     self.subject.onNext(recipes)
                 },
                 onFailure: { [weak self] error in
-                    self?.subject.onError(error)
+                    let error = error as! ClientError // swiftlint:disable:this force_cast
+                    self?.errorSubject.onNext(error)
                 }
             )
             .disposed(by: disposeBag)

--- a/KikurageTests/Repository/StubKikurageStateRepository.swift
+++ b/KikurageTests/Repository/StubKikurageStateRepository.swift
@@ -33,8 +33,8 @@ extension StubKikurageStateRepository {
     
     func getKikurageState(request: KikurageStateRequest) -> Single<KikurageState> {
         Single<KikurageState>.create { [weak self] single in
-            if let _self = self {
-                single(.success(_self.returnKikurageState))
+            if let `self` = self {
+                single(.success(self.returnKikurageState))
             }
             return Disposables.create()
         }


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🔧 改善  
- 🐛 バグ  


## やったこと
- APIClientからErrorレスポンスがVMに渡ってきた場合、onNextを使ってerrorをVCへ伝えるようにした（onErrorイベントを使用すると次にデータを読み込むタイミングでonNextイベントが発火しないため）
- 対象
  - ホーム画面
  - 栽培記録一覧画面
  - 料理記録一覧画面

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- ネットワークをOFFにしてエラーメッセージを表示後、ネットワークをONにしてリフレッシュさせリストが更新されること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- Rx参考記事
  - https://codezine.jp/article/detail/11051?p=3
  - https://techblog.glpgs.com/entry/2017/04/06/201759 （エラーハンドリング参照）
  - https://techblog.istyle.co.jp/archives/6126
  - https://yktech.hatenablog.com/entry/2019/01/03/234757 （`catchErrorJustReturn`参照）
