### PR TITLE
【全般】Presentした画面のNavigationBarの設定方法を変更

### DIFF
--- a/Kikurage/ScreenModule/PostCultivation/BaseView/PostCultivationBaseView.swift
+++ b/Kikurage/ScreenModule/PostCultivation/BaseView/PostCultivationBaseView.swift
@@ -10,11 +10,9 @@ import UIKit
 
 protocol PostCultivationBaseViewDelegate: AnyObject {
     func postCultivationBaseViewDidTappedPostButton(_ postCultivationBaseView: PostCultivationBaseView)
-    func postCultivationBaseViewDidTappedCloseButton(_ postCultivationBaseView: PostCultivationBaseView)
 }
 
 class PostCultivationBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private(set) weak var cameraCollectionView: UICollectionView!
     @IBOutlet private(set) weak var textView: UITextViewWithPlaceholder!
     @IBOutlet private weak var currentTextViewNumberLabel: UILabel!
@@ -42,9 +40,6 @@ class PostCultivationBaseView: UIView {
     @IBAction private func post(_ sender: Any) {
         delegate?.postCultivationBaseViewDidTappedPostButton(self)
     }
-    @IBAction private func close(_ sender: Any) {
-        delegate?.postCultivationBaseViewDidTappedCloseButton(self)
-    }
 }
 
 // MARK: - Initialized
@@ -54,8 +49,6 @@ extension PostCultivationBaseView {
         cameraCollectionView.register(R.nib.cameraCell)
     }
     private func initUI() {
-        // タイトル
-        navigationItem.title = R.string.localizable.screen_post_cultivation_title()
         // 背景色
         backgroundColor = .systemGroupedBackground
         cameraCollectionView.backgroundColor = .systemGroupedBackground

--- a/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.storyboard
+++ b/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5X-xd-GP8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="x5X-xd-GP8">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,21 +18,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jnh-Hi-R8f">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="YbJ-8S-yFQ">
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="b4s-6e-QMy">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                            <connections>
-                                                <action selector="close:" destination="IvK-fa-IF2" id="dic-tI-ce2"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ihW-db-xFy">
-                                <rect key="frame" x="8" y="118" width="398" height="180"/>
+                                <rect key="frame" x="8" y="74" width="398" height="180"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="180" id="5EL-Ef-TXd"/>
@@ -46,7 +33,7 @@
                                 <cells/>
                             </collectionView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Ev5-t0-9pB" customClass="UITextViewWithPlaceholder" customModule="Kikurage" customModuleProvider="target">
-                                <rect key="frame" x="8" y="313" width="398" height="50"/>
+                                <rect key="frame" x="8" y="269" width="398" height="50"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="cqx-wS-piW"/>
@@ -56,14 +43,14 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PqW-BU-m9X">
-                                <rect key="frame" x="8" y="368" width="398" height="0.5"/>
+                                <rect key="frame" x="8" y="324" width="398" height="0.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.5" id="th1-Sh-SQl"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jbb-tP-CaW">
-                                <rect key="frame" x="364.5" y="371.5" width="41.5" height="18"/>
+                                <rect key="frame" x="364.5" y="327.5" width="41.5" height="18"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zix-cg-dSg">
                                         <rect key="frame" x="0.0" y="0.0" width="9.5" height="18"/>
@@ -86,7 +73,7 @@
                                 </subviews>
                             </stackView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VXg-KC-8nl">
-                                <rect key="frame" x="8" y="409.5" width="398" height="34"/>
+                                <rect key="frame" x="8" y="365.5" width="398" height="78"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -111,9 +98,9 @@
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="PqW-BU-m9X" secondAttribute="trailing" constant="8" id="16E-jG-cD1"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="VXg-KC-8nl" secondAttribute="trailing" constant="8" id="25S-fi-avf"/>
                             <constraint firstItem="mlY-Sc-yhw" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" constant="16" id="9JV-Yc-fXl"/>
-                            <constraint firstItem="ihW-db-xFy" firstAttribute="top" secondItem="Jnh-Hi-R8f" secondAttribute="bottom" constant="30" id="AEB-I8-fKX"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="bottom" secondItem="mlY-Sc-yhw" secondAttribute="bottom" constant="10" id="Adn-cN-rBW"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="Jbb-tP-CaW" secondAttribute="trailing" constant="8" id="C5J-ZL-Tex"/>
+                            <constraint firstItem="ihW-db-xFy" firstAttribute="top" secondItem="iTf-i7-dBw" secondAttribute="top" constant="30" id="Ev9-R6-ACh"/>
                             <constraint firstItem="VXg-KC-8nl" firstAttribute="top" secondItem="Jbb-tP-CaW" secondAttribute="bottom" constant="20" id="I9X-Gl-bXj"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="ihW-db-xFy" secondAttribute="trailing" constant="8" id="M8i-II-pwg"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="mlY-Sc-yhw" secondAttribute="trailing" constant="16" id="Mpn-Nt-ZkM"/>
@@ -121,21 +108,17 @@
                             <constraint firstItem="PqW-BU-m9X" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" constant="8" id="PKT-k1-2gG"/>
                             <constraint firstItem="ihW-db-xFy" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" constant="8" id="Ts9-5d-T5l"/>
                             <constraint firstItem="Ev5-t0-9pB" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" constant="8" id="VeN-ok-wjR"/>
-                            <constraint firstItem="Jnh-Hi-R8f" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" id="Vor-0R-Pcg"/>
                             <constraint firstItem="VXg-KC-8nl" firstAttribute="leading" secondItem="iTf-i7-dBw" secondAttribute="leading" constant="8" id="Y7e-KE-0Q1"/>
-                            <constraint firstItem="Jnh-Hi-R8f" firstAttribute="top" secondItem="iTf-i7-dBw" secondAttribute="top" id="bQg-wf-Khr"/>
                             <constraint firstItem="Jbb-tP-CaW" firstAttribute="top" secondItem="PqW-BU-m9X" secondAttribute="bottom" constant="3" id="bXb-ho-ao8"/>
                             <constraint firstItem="iTf-i7-dBw" firstAttribute="trailing" secondItem="Ev5-t0-9pB" secondAttribute="trailing" constant="8" id="cem-tG-ZnH"/>
                             <constraint firstItem="mlY-Sc-yhw" firstAttribute="top" relation="lessThanOrEqual" secondItem="VXg-KC-8nl" secondAttribute="bottom" constant="363.5" id="dFb-6c-TWc"/>
                             <constraint firstItem="PqW-BU-m9X" firstAttribute="top" secondItem="Ev5-t0-9pB" secondAttribute="bottom" constant="5" id="mCi-M6-Te6"/>
-                            <constraint firstItem="Jnh-Hi-R8f" firstAttribute="trailing" secondItem="iTf-i7-dBw" secondAttribute="trailing" id="okw-So-k9W"/>
                         </constraints>
                         <connections>
                             <outlet property="cameraCollectionView" destination="ihW-db-xFy" id="BEW-eB-WjM"/>
                             <outlet property="currentTextViewNumberLabel" destination="Zix-cg-dSg" id="ECg-08-FsU"/>
                             <outlet property="dateTextField" destination="VXg-KC-8nl" id="ijK-0F-t9i"/>
                             <outlet property="maxTextViewNumberLabel" destination="Kzm-YM-Cc5" id="lP2-81-XNB"/>
-                            <outlet property="navigationItem" destination="YbJ-8S-yFQ" id="XJb-lW-ftZ"/>
                             <outlet property="postButton" destination="mlY-Sc-yhw" id="wg9-1b-RqN"/>
                             <outlet property="textView" destination="Ev5-t0-9pB" id="crk-9R-4hj"/>
                         </connections>
@@ -147,7 +130,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="subColor">
             <color red="0.86299997568130493" green="0.29800000786781311" blue="0.36899998784065247" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.swift
+++ b/Kikurage/ScreenModule/PostCultivation/ViewController/PostCultivationViewController.swift
@@ -21,7 +21,14 @@ class PostCultivationViewController: UIViewController, UIViewControllerNavigatab
         viewModel = PostCultivationViewModel(cultivationRepository: CultivationRepository())
         cameraCollectionViewModel = CameraCollectionViewModel(selectedImageMaxNumber: Constants.CameraCollectionCell.maxNumber)
         setDelegateDataSource()
+        setNavigation()
         adjustNavigationBarBackgroundColor()
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -36,6 +43,11 @@ extension PostCultivationViewController {
         baseView.configTextField(delegate: self)
         cameraCollectionViewModel.cameraCellDelegate = self
         viewModel.delegate = self
+    }
+    private func setNavigation() {
+        let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeButtonItem]
+        navigationItem.title = R.string.localizable.screen_post_cultivation_title()
     }
 }
 
@@ -54,9 +66,6 @@ extension PostCultivationViewController: PostCultivationBaseViewDelegate {
         } else {
             UIAlertController.showAlert(style: .alert, viewController: self, title: R.string.localizable.screen_post_cultivation_valid_view_date(), message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil, completionOk: nil)
         }
-    }
-    func postCultivationBaseViewDidTappedCloseButton(_ postCultivationBaseView: PostCultivationBaseView) {
-        presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Kikurage/ScreenModule/PostRecipe/BaseView/PostRecipeBaseView.swift
+++ b/Kikurage/ScreenModule/PostRecipe/BaseView/PostRecipeBaseView.swift
@@ -10,11 +10,9 @@ import UIKit
 
 protocol PostRecipeBaseViewDelegate: AnyObject {
     func postRecipeBaseViewDidTappedPostButton(_ postRecipeBaseView: PostRecipeBaseView)
-    func postRecipeBaseViewDidTappedCloseButton(_ postRecipeBaseView: PostRecipeBaseView)
 }
 
 class PostRecipeBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private(set) weak var cameraCollectionView: UICollectionView!
     @IBOutlet private(set) weak var recipeNameTextField: UITextField!
     @IBOutlet private weak var currentRecipeNameNumberLabel: UILabel!
@@ -42,9 +40,6 @@ class PostRecipeBaseView: UIView {
 
     // MARK: - Action
 
-    @IBAction private func close(_ sender: Any) {
-        delegate?.postRecipeBaseViewDidTappedCloseButton(self)
-    }
     @IBAction private func post(_ sender: Any) {
         delegate?.postRecipeBaseViewDidTappedPostButton(self)
     }
@@ -57,8 +52,6 @@ extension PostRecipeBaseView {
         cameraCollectionView.register(R.nib.cameraCell)
     }
     private func initUI() {
-        // タイトル
-        navigationItem.title = R.string.localizable.screen_post_recipe_title()
         // 背景色
         backgroundColor = .systemGroupedBackground
         cameraCollectionView.backgroundColor = .systemGroupedBackground

--- a/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.storyboard
+++ b/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PzW-Wf-n4G">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="PzW-Wf-n4G">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,21 +18,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SWT-C8-qOu">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="DZZ-Qz-zX1">
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="Rrb-DO-HFe">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                            <connections>
-                                                <action selector="close:" destination="50A-5Z-sZQ" id="Ako-vn-JXN"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="EoP-hp-Jmg">
-                                <rect key="frame" x="8" y="118" width="398" height="180"/>
+                                <rect key="frame" x="8" y="74" width="398" height="180"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="180" id="PLk-rT-pfg"/>
@@ -45,20 +32,20 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="料理名" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3IK-Vu-4GC">
-                                <rect key="frame" x="8" y="313" width="398" height="18.5"/>
+                            <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="料理名" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3IK-Vu-4GC">
+                                <rect key="frame" x="8" y="269" width="398" height="18.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cUN-uj-vOg">
-                                <rect key="frame" x="8" y="334.5" width="398" height="0.5"/>
+                                <rect key="frame" x="8" y="290.5" width="398" height="0.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.5" id="X77-bf-Cm2"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Gvi-fO-fsB">
-                                <rect key="frame" x="367.5" y="338" width="38.5" height="20.5"/>
+                                <rect key="frame" x="367.5" y="294" width="38.5" height="20.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hwk-2Q-RJ1">
                                         <rect key="frame" x="0.0" y="0.0" width="10.5" height="20.5"/>
@@ -81,7 +68,7 @@
                                 </subviews>
                             </stackView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="bxT-bv-0Ou" customClass="UITextViewWithPlaceholder" customModule="Kikurage" customModuleProvider="target">
-                                <rect key="frame" x="8" y="388.5" width="398" height="50"/>
+                                <rect key="frame" x="8" y="344.5" width="398" height="50"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="AHf-C3-Ura"/>
@@ -91,14 +78,14 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RQ8-Wk-c7K">
-                                <rect key="frame" x="8" y="441.5" width="398" height="0.5"/>
+                                <rect key="frame" x="8" y="397.5" width="398" height="0.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.5" id="nrz-k8-a3E"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="oQk-R3-0c4">
-                                <rect key="frame" x="358" y="445" width="48" height="20.5"/>
+                                <rect key="frame" x="358" y="401" width="48" height="20.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="alB-Cy-8JB">
                                         <rect key="frame" x="0.0" y="0.0" width="10.5" height="20.5"/>
@@ -121,7 +108,7 @@
                                 </subviews>
                             </stackView>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Phq-a3-1Vo">
-                                <rect key="frame" x="8" y="485.5" width="398" height="34"/>
+                                <rect key="frame" x="8" y="441.5" width="398" height="78"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -143,7 +130,6 @@
                         <viewLayoutGuide key="safeArea" id="aAq-K2-QFJ"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="SWT-C8-qOu" firstAttribute="leading" secondItem="aAq-K2-QFJ" secondAttribute="leading" id="24r-1K-ANe"/>
                             <constraint firstItem="aAq-K2-QFJ" firstAttribute="trailing" secondItem="2ju-zv-Izm" secondAttribute="trailing" constant="16" id="4Mx-Zr-y2Y"/>
                             <constraint firstItem="oQk-R3-0c4" firstAttribute="top" secondItem="RQ8-Wk-c7K" secondAttribute="bottom" constant="3" id="CLE-Rc-Zjt"/>
                             <constraint firstItem="bxT-bv-0Ou" firstAttribute="top" secondItem="Gvi-fO-fsB" secondAttribute="bottom" constant="30" id="Cvy-Jw-pRw"/>
@@ -153,15 +139,13 @@
                             <constraint firstItem="3IK-Vu-4GC" firstAttribute="top" secondItem="EoP-hp-Jmg" secondAttribute="bottom" constant="15" id="MVU-oP-ZE2"/>
                             <constraint firstItem="3IK-Vu-4GC" firstAttribute="leading" secondItem="aAq-K2-QFJ" secondAttribute="leading" constant="8" id="Qdb-yP-3xj"/>
                             <constraint firstItem="2ju-zv-Izm" firstAttribute="leading" secondItem="aAq-K2-QFJ" secondAttribute="leading" constant="16" id="V2Q-NB-QO3"/>
+                            <constraint firstItem="EoP-hp-Jmg" firstAttribute="top" secondItem="aAq-K2-QFJ" secondAttribute="top" constant="30" id="V80-fl-TYl"/>
                             <constraint firstItem="Phq-a3-1Vo" firstAttribute="top" secondItem="oQk-R3-0c4" secondAttribute="bottom" constant="20" id="V8O-Se-7ag"/>
                             <constraint firstItem="aAq-K2-QFJ" firstAttribute="trailing" secondItem="cUN-uj-vOg" secondAttribute="trailing" constant="8" id="VWq-kA-QzE"/>
                             <constraint firstItem="aAq-K2-QFJ" firstAttribute="trailing" secondItem="oQk-R3-0c4" secondAttribute="trailing" constant="8" id="Y89-4d-Fni"/>
-                            <constraint firstItem="EoP-hp-Jmg" firstAttribute="top" secondItem="SWT-C8-qOu" secondAttribute="bottom" constant="30" id="aW8-wH-aRJ"/>
                             <constraint firstItem="aAq-K2-QFJ" firstAttribute="trailing" secondItem="Phq-a3-1Vo" secondAttribute="trailing" constant="8" id="dlC-my-vQ0"/>
                             <constraint firstItem="Gvi-fO-fsB" firstAttribute="top" secondItem="cUN-uj-vOg" secondAttribute="bottom" constant="3" id="eBe-n9-IS5"/>
-                            <constraint firstItem="SWT-C8-qOu" firstAttribute="top" secondItem="aAq-K2-QFJ" secondAttribute="top" id="gZY-S5-O8B"/>
                             <constraint firstItem="aAq-K2-QFJ" firstAttribute="trailing" secondItem="RQ8-Wk-c7K" secondAttribute="trailing" constant="8" id="go8-yg-cbU"/>
-                            <constraint firstItem="SWT-C8-qOu" firstAttribute="trailing" secondItem="aAq-K2-QFJ" secondAttribute="trailing" id="j3j-Ex-cfQ"/>
                             <constraint firstItem="RQ8-Wk-c7K" firstAttribute="leading" secondItem="aAq-K2-QFJ" secondAttribute="leading" constant="8" id="jZu-iL-EOq"/>
                             <constraint firstItem="2ju-zv-Izm" firstAttribute="top" relation="lessThanOrEqual" secondItem="Phq-a3-1Vo" secondAttribute="bottom" constant="287.5" id="k9A-Wk-06a"/>
                             <constraint firstItem="RQ8-Wk-c7K" firstAttribute="top" secondItem="bxT-bv-0Ou" secondAttribute="bottom" constant="3" id="kcb-cs-Tfl"/>
@@ -180,7 +164,6 @@
                             <outlet property="dateTextField" destination="Phq-a3-1Vo" id="j23-BY-aCA"/>
                             <outlet property="maxRecipeMemoNumberLabel" destination="gEz-mn-L6i" id="1l3-2L-jhx"/>
                             <outlet property="maxRecipeNameNumberLabel" destination="aab-7L-BXX" id="jkR-27-U7o"/>
-                            <outlet property="navigationItem" destination="DZZ-Qz-zX1" id="elG-lR-bx6"/>
                             <outlet property="postButton" destination="2ju-zv-Izm" id="5Dj-qX-RXU"/>
                             <outlet property="recipeMemoTextView" destination="bxT-bv-0Ou" id="Igl-yZ-dgw"/>
                             <outlet property="recipeNameTextField" destination="3IK-Vu-4GC" id="jdU-iH-8dQ"/>
@@ -193,7 +176,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="subColor">
             <color red="0.86299997568130493" green="0.29800000786781311" blue="0.36899998784065247" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.swift
+++ b/Kikurage/ScreenModule/PostRecipe/ViewController/PostRecipeViewController.swift
@@ -19,7 +19,14 @@ class PostRecipeViewController: UIViewController, UIViewControllerNavigatable {
         cameraCollectionViewModel = CameraCollectionViewModel(selectedImageMaxNumber: Constants.CameraCollectionCell.maxNumber)
         viewModel = PostRecipeViewModel(recipeRepository: RecipeRepository())
         setDelegateDataSource()
+        setNavigation()
         adjustNavigationBarBackgroundColor()
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -33,6 +40,11 @@ extension PostRecipeViewController {
         baseView.cofigCollectionView(delegate: self, dataSource: cameraCollectionViewModel)
         cameraCollectionViewModel.cameraCellDelegate = self
         viewModel.delegate = self
+    }
+    private func setNavigation() {
+        let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeButtonItem]
+        navigationItem.title = R.string.localizable.screen_post_recipe_title()
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/BaseView/CalendarBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/BaseView/CalendarBaseView.swift
@@ -9,25 +9,12 @@
 import UIKit
 import HorizonCalendar
 
-protocol CalendarBaseViewDelegate: AnyObject {
-    func calendarBaseViewDidTapCloseButton(_ calendarBaseView: CalendarBaseView)
-}
-
 class CalendarBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private weak var contentView: UIView!
-
-    weak var delegate: CalendarBaseViewDelegate?
 
     override func awakeFromNib() {
         super.awakeFromNib()
         initUI()
-    }
-
-    // MARK: - Action
-
-    @IBAction private func close(_ sender: Any) {
-        delegate?.calendarBaseViewDidTapCloseButton(self)
     }
 }
 
@@ -36,7 +23,6 @@ class CalendarBaseView: UIView {
 extension CalendarBaseView {
     private func initUI() {
         contentView.backgroundColor = .systemGroupedBackground
-        navigationItem.title = R.string.localizable.side_menu_clendar_title()
     }
     private func initCalendarView(_ cultivationStartDateComponents: DateComponents, _ cultivationTerm: Int) {
         // Calendar

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Pht-LK-BIt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Pht-LK-BIt">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,37 +18,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cbj-K3-STj">
-                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="852"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DKv-ph-VyN">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="wls-fy-12Z">
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="O0Y-Ez-wft">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                            <connections>
-                                                <action selector="close:" destination="uai-5v-WLU" id="9Tq-5f-uJf"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vQh-Z5-JeZ"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="Cbj-K3-STj" secondAttribute="bottom" id="1O4-XG-0sF"/>
                             <constraint firstItem="vQh-Z5-JeZ" firstAttribute="trailing" secondItem="Cbj-K3-STj" secondAttribute="trailing" id="Dsf-hJ-J37"/>
-                            <constraint firstItem="DKv-ph-VyN" firstAttribute="leading" secondItem="vQh-Z5-JeZ" secondAttribute="leading" id="a2r-K9-Va7"/>
-                            <constraint firstItem="DKv-ph-VyN" firstAttribute="trailing" secondItem="vQh-Z5-JeZ" secondAttribute="trailing" id="aoI-oB-94G"/>
-                            <constraint firstItem="DKv-ph-VyN" firstAttribute="top" secondItem="vQh-Z5-JeZ" secondAttribute="top" id="mwm-Ov-sc8"/>
-                            <constraint firstItem="Cbj-K3-STj" firstAttribute="top" secondItem="DKv-ph-VyN" secondAttribute="bottom" id="nU8-1s-ooB"/>
                             <constraint firstItem="Cbj-K3-STj" firstAttribute="leading" secondItem="vQh-Z5-JeZ" secondAttribute="leading" id="rXj-HJ-ZWe"/>
+                            <constraint firstItem="Cbj-K3-STj" firstAttribute="top" secondItem="vQh-Z5-JeZ" secondAttribute="top" id="rge-3S-qJ1"/>
                         </constraints>
                         <connections>
                             <outlet property="contentView" destination="Cbj-K3-STj" id="xLd-0r-ATc"/>
-                            <outlet property="navigationItem" destination="wls-fy-12Z" id="EFP-5v-lrM"/>
                         </connections>
                     </view>
                 </viewController>
@@ -58,10 +41,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Calendar/ViewController/CalendarViewController.swift
@@ -18,10 +18,17 @@ class CalendarViewController: UIViewController {
         super.viewDidLoad()
         viewModel = CalendarViewModel(kikurageUserRepository: KikurageUserRepository())
         setDelegateDataSource()
+        setNavigation()
 
         if let userId = LoginHelper.shared.kikurageUserId {
             viewModel.loadKikurageUser(uid: userId)
         }
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -29,16 +36,12 @@ class CalendarViewController: UIViewController {
 
 extension CalendarViewController {
     private func setDelegateDataSource() {
-        baseView.delegate = self
         viewModel.delegate = self
     }
-}
-
-// MARK: - CalendarBaseView Delegate
-
-extension CalendarViewController: CalendarBaseViewDelegate {
-    func calendarBaseViewDidTapCloseButton(_ calendarBaseView: CalendarBaseView) {
-        presentingViewController?.dismiss(animated: true, completion: nil)
+    private func setNavigation() {
+        let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeButtonItem]
+        navigationItem.title = R.string.localizable.side_menu_clendar_title()
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Dictionary/BaseView/DictionaryBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Dictionary/BaseView/DictionaryBaseView.swift
@@ -14,7 +14,6 @@ protocol DictionaryBaseViewDelegate: AnyObject {
 }
 
 class DictionaryBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private weak var containerView: UIView!
     @IBOutlet private weak var segmentedControl: UISegmentedControl!
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/DictionaryViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/DictionaryViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,17 +17,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2G5-vh-jAv">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="BZD-3P-Dkz">
-                                        <nil key="title"/>
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="3rz-de-TpT">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="kyO-hk-xK2">
                                 <rect key="frame" x="8" y="52" width="398" height="32"/>
                                 <segments>
@@ -45,20 +34,16 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="2G5-vh-jAv" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="2cq-dG-IWN"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="kyO-hk-xK2" secondAttribute="trailing" constant="8" id="2m4-NW-gOW"/>
                             <constraint firstItem="esU-SI-Rh3" firstAttribute="top" secondItem="kyO-hk-xK2" secondAttribute="bottom" constant="8" id="7bA-7U-TPU"/>
-                            <constraint firstItem="kyO-hk-xK2" firstAttribute="top" secondItem="2G5-vh-jAv" secondAttribute="bottom" constant="8" id="TN6-Cz-Vfk"/>
+                            <constraint firstItem="kyO-hk-xK2" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="8" id="Kjd-Tc-XQS"/>
                             <constraint firstItem="esU-SI-Rh3" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="UUP-rz-kU3"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="esU-SI-Rh3" secondAttribute="bottom" id="YFA-qX-y88"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="esU-SI-Rh3" secondAttribute="trailing" id="gwF-5q-V1y"/>
-                            <constraint firstItem="2G5-vh-jAv" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="kAP-tf-qxl"/>
                             <constraint firstItem="kyO-hk-xK2" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="8" id="x3B-da-eza"/>
-                            <constraint firstItem="2G5-vh-jAv" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="yNg-O5-rBL"/>
                         </constraints>
                         <connections>
                             <outlet property="containerView" destination="esU-SI-Rh3" id="upp-3d-TL6"/>
-                            <outlet property="navigationItem" destination="BZD-3P-Dkz" id="ZEy-Jg-3qP"/>
                             <outlet property="segmentedControl" destination="kyO-hk-xK2" id="kmA-Sj-7qp"/>
                         </connections>
                     </view>
@@ -69,10 +54,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/DictionaryViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/DictionaryViewController.swift
@@ -25,9 +25,16 @@ class DictionaryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigation()
         baseView.delegate = self
 
         setContainerViewController(dictionaryTriviaVC)
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -39,6 +46,11 @@ extension DictionaryViewController {
         addChild(vc)
         baseView.addContainerView(vc.view)
         vc.didMove(toParent: self)
+    }
+    private func setNavigation() {
+        let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeButtonItem]
+        navigationItem.title = ""
     }
     private func removeContainerViewController() {
         guard let vc = currentViewController else { return }

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/BaseView/GraphBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/BaseView/GraphBaseView.swift
@@ -14,12 +14,7 @@ enum GraphDataType {
     case humidity
 }
 
-protocol GraphBaseViewDelegate: AnyObject {
-    func graphBaseViewDidTapCloseButton(_ graphBaseView: GraphBaseView)
-}
-
 class GraphBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private weak var temperatureLabel: UILabel!
     @IBOutlet private weak var humidityLabel: UILabel!
     @IBOutlet private weak var temperatureLineChartView: LineChartView!
@@ -28,19 +23,11 @@ class GraphBaseView: UIView {
     @IBOutlet private weak var temperatureActivityIndicator: UIActivityIndicatorView!
     @IBOutlet private weak var humidityActivityIndicator: UIActivityIndicatorView!
 
-    weak var delegate: GraphBaseViewDelegate?
-
     private let chartViewHelper = ChartViewHelper()
 
     override func awakeFromNib() {
         super.awakeFromNib()
         initUI()
-    }
-
-    // MARK: - Action
-
-    @IBAction private func close(_ sender: Any) {
-        delegate?.graphBaseViewDidTapCloseButton(self)
     }
 }
 
@@ -49,7 +36,6 @@ class GraphBaseView: UIView {
 extension GraphBaseView {
     private func initUI() {
         // タイトル
-        navigationItem.title = R.string.localizable.side_menu_graph_title()
         temperatureLabel.text = R.string.localizable.side_menu_graph_temperature_subtitle()
         humidityLabel.text = R.string.localizable.side_menu_graph_humidity_subtitle()
         // 背景色

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cQB-zQ-jsr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="cQB-zQ-jsr">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,27 +17,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8vh-6Y-Jv2">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="bqu-up-xhg">
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="9Ie-1Q-Syt">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                            <connections>
-                                                <action selector="close:" destination="rav-Yu-zgV" id="QNP-Hq-fkr"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oef-Md-Gap">
-                                <rect key="frame" x="20" y="128" width="374" height="0.0"/>
+                                <rect key="frame" x="20" y="84" width="374" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0V4-CD-NPR" customClass="LineChartView" customModule="Charts">
-                                <rect key="frame" x="10" y="138" width="394" height="221.5"/>
+                                <rect key="frame" x="10" y="94" width="394" height="221.5"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="asM-aQ-3CH">
                                         <rect key="frame" x="187" y="101" width="20" height="20"/>
@@ -51,13 +38,13 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="96e-i6-yWq">
-                                <rect key="frame" x="20" y="399.5" width="374" height="0.0"/>
+                                <rect key="frame" x="20" y="355.5" width="374" height="0.0"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="r9v-nG-Lqq" customClass="LineChartView" customModule="Charts">
-                                <rect key="frame" x="10" y="409.5" width="394" height="222"/>
+                                <rect key="frame" x="10" y="365.5" width="394" height="222"/>
                                 <subviews>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="4P1-rz-aXX">
                                         <rect key="frame" x="187" y="101" width="20" height="20"/>
@@ -83,18 +70,14 @@
                             <constraint firstItem="n5m-bS-YIJ" firstAttribute="trailing" secondItem="0V4-CD-NPR" secondAttribute="trailing" constant="10" id="IUK-Q2-huj"/>
                             <constraint firstItem="0V4-CD-NPR" firstAttribute="leading" secondItem="n5m-bS-YIJ" secondAttribute="leading" constant="10" id="MIq-Rm-tvF"/>
                             <constraint firstItem="96e-i6-yWq" firstAttribute="leading" secondItem="n5m-bS-YIJ" secondAttribute="leading" constant="20" id="RPv-Oh-DHU"/>
-                            <constraint firstItem="8vh-6Y-Jv2" firstAttribute="leading" secondItem="n5m-bS-YIJ" secondAttribute="leading" id="TQp-Oj-tom"/>
+                            <constraint firstItem="Oef-Md-Gap" firstAttribute="top" secondItem="n5m-bS-YIJ" secondAttribute="top" constant="40" id="VxR-V6-tia"/>
                             <constraint firstItem="96e-i6-yWq" firstAttribute="top" secondItem="0V4-CD-NPR" secondAttribute="bottom" constant="40" id="dDV-a7-jnz"/>
-                            <constraint firstItem="8vh-6Y-Jv2" firstAttribute="top" secondItem="n5m-bS-YIJ" secondAttribute="top" id="ev3-63-O8m"/>
-                            <constraint firstItem="Oef-Md-Gap" firstAttribute="top" secondItem="8vh-6Y-Jv2" secondAttribute="bottom" constant="40" id="p5Q-jU-XDb"/>
                             <constraint firstItem="n5m-bS-YIJ" firstAttribute="trailing" secondItem="Oef-Md-Gap" secondAttribute="trailing" constant="20" id="qwr-41-Mqo"/>
-                            <constraint firstItem="8vh-6Y-Jv2" firstAttribute="trailing" secondItem="n5m-bS-YIJ" secondAttribute="trailing" id="zME-Lb-gGN"/>
                         </constraints>
                         <connections>
                             <outlet property="humidityActivityIndicator" destination="4P1-rz-aXX" id="yXr-eg-eK5"/>
                             <outlet property="humidityLabel" destination="96e-i6-yWq" id="vNw-IF-AUf"/>
                             <outlet property="humidityLineChartView" destination="r9v-nG-Lqq" id="fwx-vd-ZJP"/>
-                            <outlet property="navigationItem" destination="bqu-up-xhg" id="OmL-8C-az4"/>
                             <outlet property="temperatureActivityIndicator" destination="asM-aQ-3CH" id="xxK-Qy-Xth"/>
                             <outlet property="temperatureLabel" destination="Oef-Md-Gap" id="BlQ-De-m7m"/>
                             <outlet property="temperatureLineChartView" destination="0V4-CD-NPR" id="1nN-HX-TMP"/>
@@ -107,10 +90,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Graph/ViewController/GraphViewController.swift
@@ -18,7 +18,14 @@ class GraphViewController: UIViewController {
         super.viewDidLoad()
         viewModel = GraphViewModel(kikurageStateRepository: KikurageStateRepository(), kikurageUserRepository: KikurageUserRepository())
         setDelegateDataSource()
+        setNavigation()
         loadKikurageUser()
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -26,8 +33,12 @@ class GraphViewController: UIViewController {
 
 extension GraphViewController {
     private func setDelegateDataSource() {
-        baseView.delegate = self
         viewModel.delegate = self
+    }
+    private func setNavigation() {
+        let closeBarButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeBarButtonItem]
+        navigationItem.title = R.string.localizable.side_menu_graph_title()
     }
     private func loadKikurageUser() {
         guard let userId = LoginHelper.shared.kikurageUserId else { return }
@@ -37,14 +48,6 @@ extension GraphViewController {
     private func loadKikurageStateGraph() {
         guard let kikurageUser = viewModel.kikurageUser else { return }
         viewModel.loadKikurageStateGraph(productId: kikurageUser.productKey)
-    }
-}
-
-// MARK: - GraphBaseView Delegate
-
-extension GraphViewController: GraphBaseViewDelegate {
-    func graphBaseViewDidTapCloseButton(_ graphBaseView: GraphBaseView) {
-        presentingViewController?.dismiss(animated: true, completion: nil)
     }
 }
 

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/BaseView/SettingBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/BaseView/SettingBaseView.swift
@@ -11,11 +11,9 @@ import UIKit
 protocol SettingBaseViewDelegate: AnyObject {
     func settingBaseViewDidTappedEditButton(_ settingBaseView: SettingBaseView)
     func settingBaseViewDidTappedUserImageView(_ settingBaseView: SettingBaseView)
-    func settingBaseViewDidTappedCloseButton(_ settingBaseView: SettingBaseView)
 }
 
 class SettingBaseView: UIView {
-    @IBOutlet private weak var navigationItem: UINavigationItem!
     @IBOutlet private weak var userImageView: UIImageView!
     @IBOutlet private weak var kikurageNameTextField: UITextField!
     @IBOutlet private weak var editButton: UIButton!
@@ -35,16 +33,12 @@ class SettingBaseView: UIView {
     @IBAction private func editUserImage(_ sender: Any) {
         delegate?.settingBaseViewDidTappedUserImageView(self)
     }
-    @IBAction private func close(_ sender: Any) {
-        delegate?.settingBaseViewDidTappedCloseButton(self)
-    }
 }
 
 // MARK: - Initialized
 
 extension SettingBaseView {
     private func initUI() {
-        navigationItem.title = R.string.localizable.side_menu_setting_title()
         backgroundColor = .systemGroupedBackground
 
         userImageView.image = R.image.hakase()

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.storyboard
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,21 +18,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rRU-iD-Np6">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                                <items>
-                                    <navigationItem id="Jo2-fU-bkm">
-                                        <barButtonItem key="leftBarButtonItem" image="xmark" catalog="system" id="10M-c2-k7n">
-                                            <color key="tintColor" systemColor="labelColor"/>
-                                            <connections>
-                                                <action selector="close:" destination="5EZ-qb-Rvc" id="XRe-DB-8aK"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="k2q-UE-jw0">
-                                <rect key="frame" x="127" y="128" width="160" height="160"/>
+                                <rect key="frame" x="127" y="84" width="160" height="160"/>
                                 <gestureRecognizers/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="160" id="CFU-AR-3Vo"/>
@@ -55,12 +42,12 @@
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Sw0-8n-Pej">
-                                <rect key="frame" x="16" y="328" width="382" height="25.5"/>
+                                <rect key="frame" x="16" y="284" width="382" height="25.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uVm-zr-Fiq">
-                                <rect key="frame" x="16" y="356.5" width="382" height="0.5"/>
+                                <rect key="frame" x="16" y="312.5" width="382" height="0.5"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.5" id="skA-bz-6dj"/>
@@ -70,25 +57,21 @@
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="rRU-iD-Np6" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="2EF-Bo-ACE"/>
                             <constraint firstItem="uVm-zr-Fiq" firstAttribute="top" secondItem="Sw0-8n-Pej" secondAttribute="bottom" constant="3" id="3jA-wy-imi"/>
                             <constraint firstItem="Sw0-8n-Pej" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="5WL-Y4-fUx"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="q1G-9p-BEi" secondAttribute="bottom" constant="10" id="6ig-qb-1cV"/>
                             <constraint firstItem="uVm-zr-Fiq" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="8tx-F4-FBB"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="rRU-iD-Np6" secondAttribute="trailing" id="IdZ-Ef-clP"/>
+                            <constraint firstItem="k2q-UE-jw0" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="40" id="CEb-qM-icd"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="Sw0-8n-Pej" secondAttribute="trailing" constant="16" id="aq1-hq-DeH"/>
-                            <constraint firstItem="k2q-UE-jw0" firstAttribute="top" secondItem="rRU-iD-Np6" secondAttribute="bottom" constant="40" id="bC7-qQ-a9j"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="uVm-zr-Fiq" secondAttribute="trailing" constant="16" id="eDi-Hc-4nu"/>
                             <constraint firstItem="q1G-9p-BEi" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="fxn-YD-f0c"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="q1G-9p-BEi" secondAttribute="trailing" constant="16" id="iAq-oq-Xrf"/>
-                            <constraint firstItem="rRU-iD-Np6" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="m36-SX-pWZ"/>
                             <constraint firstItem="k2q-UE-jw0" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="prU-gD-k1D"/>
                             <constraint firstItem="Sw0-8n-Pej" firstAttribute="top" secondItem="k2q-UE-jw0" secondAttribute="bottom" constant="40" id="vnh-aB-vwK"/>
                         </constraints>
                         <connections>
                             <outlet property="editButton" destination="q1G-9p-BEi" id="aJA-rV-qjF"/>
                             <outlet property="kikurageNameTextField" destination="Sw0-8n-Pej" id="N8L-Mc-AoF"/>
-                            <outlet property="navigationItem" destination="Jo2-fU-bkm" id="Zlz-Ks-4RK"/>
                             <outlet property="userImageView" destination="k2q-UE-jw0" id="B9y-sa-fBb"/>
                         </connections>
                     </view>
@@ -106,13 +89,9 @@
         </scene>
     </scenes>
     <resources>
-        <image name="xmark" catalog="system" width="128" height="113"/>
         <namedColor name="subColor">
             <color red="0.86299997568130493" green="0.29800000786781311" blue="0.36899998784065247" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Setting/ViewController/SettingViewController.swift
@@ -13,14 +13,23 @@ class SettingViewController: UIViewController {
     private var baseView: SettingBaseView { self.view as! SettingBaseView } // sswiftlint:disable:this force_cast
     private var viewModel: SettingViewModel!
 
+    // MARK: - Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
         viewModel = SettingViewModel(kikurageUserRepository: KikurageUserRepository())
         setDelegateDataSource()
+        setNavigation()
 
         if let userId = LoginHelper.shared.kikurageUserId {
             viewModel.loadKikurageUser(uid: userId)
         }
+    }
+
+    // MARK: - Action
+
+    @objc private func close(_ sender: UIBarButtonItem) {
+        presentingViewController?.dismiss(animated: true)
     }
 }
 
@@ -30,6 +39,11 @@ extension SettingViewController {
     private func setDelegateDataSource() {
         baseView.delegate = self
         viewModel.delegate = self
+    }
+    private func setNavigation() {
+        let closeButtonItem = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(close(_:)))
+        navigationItem.rightBarButtonItems = [closeButtonItem]
+        navigationItem.title = R.string.localizable.side_menu_setting_title()
     }
 }
 
@@ -41,9 +55,6 @@ extension SettingViewController: SettingBaseViewDelegate {
     }
     func settingBaseViewDidTappedEditButton(_ settingBaseView: SettingBaseView) {
         // FIXME: ViewModelにあるkikurageUserを更新する処理を書く
-    }
-    func settingBaseViewDidTappedCloseButton(_ settingBaseView: SettingBaseView) {
-        dismiss(animated: true, completion: nil)
     }
 }
 


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🔧 改善  
- 🐛 バグ  


## やったこと
- NavigationItemはStoryboardではなく、コードから設定するようにした
- 対象の画面
  - カレンダー
  - グラフ
  - 設定
  - 豆知識
  - 栽培記録保存
  - 料理記録保存

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- iPhone11Pro / iOS15.5
- NavigationBarの位置が画面上寄せになっていること
- 閉じるマーク（✖️）を押したら画面が閉じること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- 特になし
