### PR TITLE
【料理記録一覧・栽培記録一覧】リストがない場合の表示をSwiftUIで記述

### DIFF
--- a/Kikurage.xcodeproj/project.pbxproj
+++ b/Kikurage.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		9CBD27FF275845EE007191CE /* AppConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBD27FE275845EE007191CE /* AppConfig.swift */; };
 		9CBD6C422540F75C005531F4 /* KikurageStateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBD6C412540F75C005531F4 /* KikurageStateHelper.swift */; };
 		9CBD6C4525410707005531F4 /* KikurageUserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBD6C4425410707005531F4 /* KikurageUserRepository.swift */; };
+		9CBE673A28BA5879002DA020 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBE673928BA5879002DA020 /* EmptyView.swift */; };
 		9CBF6720276DF3E800081340 /* HomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBF671F276DF3E800081340 /* HomeViewModelTests.swift */; };
 		9CBF6723276E00E400081340 /* StubKikurageStateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBF6722276E00E400081340 /* StubKikurageStateRepository.swift */; };
 		9CC103B1270818A200067823 /* LoginUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC103B0270818A200067823 /* LoginUser.swift */; };
@@ -408,6 +409,7 @@
 		9CBD27FE275845EE007191CE /* AppConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfig.swift; sourceTree = "<group>"; };
 		9CBD6C412540F75C005531F4 /* KikurageStateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageStateHelper.swift; sourceTree = "<group>"; };
 		9CBD6C4425410707005531F4 /* KikurageUserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageUserRepository.swift; sourceTree = "<group>"; };
+		9CBE673928BA5879002DA020 /* EmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyView.swift; sourceTree = "<group>"; };
 		9CBF671F276DF3E800081340 /* HomeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModelTests.swift; sourceTree = "<group>"; };
 		9CBF6722276E00E400081340 /* StubKikurageStateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubKikurageStateRepository.swift; sourceTree = "<group>"; };
 		9CC103B0270818A200067823 /* LoginUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUser.swift; sourceTree = "<group>"; };
@@ -1070,6 +1072,7 @@
 				9C2F15A325930697006480ED /* CarouselCollectionFlowLayout.swift */,
 				9C7E14E72563F9F500D2D8EF /* UITextViewWithPlaceholder.swift */,
 				9CAC930427894E990033DA33 /* LoadingThumbnailView.swift */,
+				9CBE673928BA5879002DA020 /* EmptyView.swift */,
 				9C82B429253068CF00E650B5 /* XibView.swift */,
 				9CAFF9A2255CC57800418745 /* CollectionViewCell */,
 			);
@@ -1987,6 +1990,7 @@
 				9C751F81257E0FC000A3D90B /* UIAlertController+Extension.swift in Sources */,
 				9CAFDC0F2780482900C40094 /* SettingViewModel.swift in Sources */,
 				9CE1EE4327D4D91E00B5BE9C /* NavigationProtocol+Cultivation.swift in Sources */,
+				9CBE673A28BA5879002DA020 /* EmptyView.swift in Sources */,
 				9C9B6C712770B0F7004B2D62 /* SideMenuViewModel.swift in Sources */,
 				9CA7627F26E26B70000F7EE2 /* TopViewController.swift in Sources */,
 				9CAAF9DF2805C6B4000C671D /* KikurageCultivationRequest.swift in Sources */,

--- a/Kikurage/App/AppRootController.swift
+++ b/Kikurage/App/AppRootController.swift
@@ -121,11 +121,13 @@ extension AppRootController: AppPresenterDelegate {
     func didSuccessGetKikurageInfo(kikurageInfo: (user: KikurageUser?, state: KikurageState?)) {
         DispatchQueue.main.async {
             self.showHomePage(kikurageInfo: kikurageInfo)
+            self.kikurageHUD.removeFromSuperview()
         }
     }
     func didFailedGetKikurageInfo(errorMessage: String) {
         DispatchQueue.main.async {
             self.showTopPage()
+            self.kikurageHUD.removeFromSuperview()
         }
     }
 }

--- a/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
+++ b/Kikurage/ScreenModule/Cultivation/BaseView/CultivationBaseView.swift
@@ -12,7 +12,6 @@ class CultivationBaseView: UIView {
     @IBOutlet private(set) weak var postPageButton: UIButton!
     @IBOutlet private(set) weak var collectionView: UICollectionView!
     @IBOutlet private weak var flowLayout: UICollectionViewFlowLayout!
-    @IBOutlet private weak var noCultivationLabel: UILabel!
 
     // MARK: - Lifecycle
 
@@ -28,10 +27,6 @@ class CultivationBaseView: UIView {
 extension CultivationBaseView {
     private func initUI() {
         collectionView.backgroundColor = .systemGroupedBackground
-
-        noCultivationLabel.text = R.string.localizable.screen_cultivation_no_cultivation()
-        noCultivationLabel.textColor = .darkGray
-        noCultivationLabel.isHidden = true
     }
     private func setCollectionView() {
         flowLayout.estimatedItemSize = .zero
@@ -47,8 +42,5 @@ extension CultivationBaseView {
 extension CultivationBaseView {
     func setRefreshControlInCollectionView(_ refresh: UIRefreshControl) {
         collectionView.refreshControl = refresh
-    }
-    func noCultivationLabelIsHidden(_ isHidden: Bool) {
-        noCultivationLabel.isHidden = isHidden
     }
 }

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="afA-8l-vfe">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="afA-8l-vfe">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -28,12 +28,6 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ifZ-v7-SaM">
-                                <rect key="frame" x="15" y="448" width="384" height="0.0"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KeL-SW-wEN">
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
@@ -41,21 +35,16 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Jar-At-3Vx"/>
                         <constraints>
-                            <constraint firstItem="ifZ-v7-SaM" firstAttribute="centerX" secondItem="JsX-gy-r0o" secondAttribute="centerX" id="938-FX-2PD"/>
-                            <constraint firstItem="ifZ-v7-SaM" firstAttribute="leading" secondItem="Jar-At-3Vx" secondAttribute="leading" constant="15" id="DQ0-fq-TtM"/>
                             <constraint firstAttribute="bottom" secondItem="2PN-c2-6av" secondAttribute="bottom" id="HKf-le-7NM"/>
                             <constraint firstItem="Jar-At-3Vx" firstAttribute="trailing" secondItem="2PN-c2-6av" secondAttribute="trailing" id="Jhx-xj-YaZ"/>
                             <constraint firstItem="Jar-At-3Vx" firstAttribute="trailing" secondItem="KeL-SW-wEN" secondAttribute="trailing" constant="20" id="Phj-et-thY"/>
                             <constraint firstItem="2PN-c2-6av" firstAttribute="top" secondItem="Jar-At-3Vx" secondAttribute="top" id="VS8-nh-Pzc"/>
                             <constraint firstItem="Jar-At-3Vx" firstAttribute="bottom" secondItem="KeL-SW-wEN" secondAttribute="bottom" constant="20" id="Zb8-YU-yRp"/>
-                            <constraint firstItem="Jar-At-3Vx" firstAttribute="trailing" secondItem="ifZ-v7-SaM" secondAttribute="trailing" constant="15" id="faM-Pd-xjI"/>
-                            <constraint firstItem="ifZ-v7-SaM" firstAttribute="centerY" secondItem="JsX-gy-r0o" secondAttribute="centerY" id="fje-AV-nhz"/>
                             <constraint firstItem="2PN-c2-6av" firstAttribute="leading" secondItem="Jar-At-3Vx" secondAttribute="leading" id="kbu-pP-0QK"/>
                         </constraints>
                         <connections>
                             <outlet property="collectionView" destination="2PN-c2-6av" id="e17-CS-I8w"/>
                             <outlet property="flowLayout" destination="jcd-Tx-g9N" id="5uj-P7-mJt"/>
-                            <outlet property="noCultivationLabel" destination="ifZ-v7-SaM" id="6Qg-VB-zhD"/>
                             <outlet property="postPageButton" destination="KeL-SW-wEN" id="Opo-mn-SeC"/>
                         </connections>
                     </view>

--- a/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
+++ b/Kikurage/ScreenModule/Cultivation/ViewController/CultivationViewController.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 class CultivationViewController: UIViewController, UIViewControllerNavigatable, CultivationAccessable {
     private var baseView: CultivationBaseView { self.view as! CultivationBaseView } // swiftlint:disable:this force_cast
+    private var emptyView: UIView!
     private var viewModel: CultivationViewModel!
 
     private let disposeBag = RxSwift.DisposeBag()
@@ -65,6 +66,13 @@ extension CultivationViewController {
     private func setDelegateDataSource() {
         baseView.collectionView.delegate = self
     }
+    private func displayEmptyView(cultivations: [KikurageCultivationTuple]) {
+        if cultivations.isEmpty {
+            emptyView = addEmptyView(type: .notFoundCultivation)
+        } else {
+            emptyView?.removeFromSuperview()
+        }
+    }
 }
 
 // MARK: - Rx
@@ -85,7 +93,7 @@ extension CultivationViewController {
                     HUD.hide()
                     self?.baseView.collectionView.refreshControl?.endRefreshing()
                     self?.baseView.collectionView.reloadData()
-                    self?.baseView.noCultivationLabelIsHidden(!cultivations.isEmpty)
+                    self?.displayEmptyView(cultivations: cultivations)
                 }
             }
         )

--- a/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
+++ b/Kikurage/ScreenModule/Recipe/BaseView/RecipeBaseView.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class RecipeBaseView: UIView {
     @IBOutlet private(set) weak var tableView: UITableView!
-    @IBOutlet private weak var noRecipeLabel: UILabel!
     @IBOutlet private(set) weak var postPageButton: UIButton!
 
     override func awakeFromNib() {
@@ -27,10 +26,6 @@ extension RecipeBaseView {
         backgroundColor = .systemGroupedBackground
         tableView.backgroundColor = .systemGroupedBackground
         tableView.separatorStyle = .none
-
-        noRecipeLabel.text = R.string.localizable.screen_recipe_no_recipe()
-        noRecipeLabel.textColor = .darkGray
-        noRecipeLabel.isHidden = true
     }
     private func setTableView() {
         // セル選択を不可にする（料理記録詳細ページは無いため）
@@ -49,8 +44,5 @@ extension RecipeBaseView {
     }
     func configTableView(delegate: UITableViewDelegate) {
         tableView.delegate = delegate
-    }
-    func noRecipeLabelIsHidden(_ isHidden: Bool) {
-        noRecipeLabel.isHidden = isHidden
     }
 }

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Yn1-qf-8LL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Yn1-qf-8LL">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,12 +21,6 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" name="themeColor"/>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2F5-2R-J3a">
-                                <rect key="frame" x="15" y="448" width="384" height="0.0"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q3g-dt-07M">
                                 <rect key="frame" x="331" y="779" width="63" height="63"/>
                                 <state key="normal" image="addMemoButton"/>
@@ -35,19 +29,14 @@
                         <viewLayoutGuide key="safeArea" id="49h-m6-Xnv"/>
                         <color key="backgroundColor" name="themeColor"/>
                         <constraints>
-                            <constraint firstItem="49h-m6-Xnv" firstAttribute="trailing" secondItem="2F5-2R-J3a" secondAttribute="trailing" constant="15" id="ApE-Gm-Fvi"/>
                             <constraint firstItem="49h-m6-Xnv" firstAttribute="bottom" secondItem="x1J-99-6qg" secondAttribute="bottom" id="EyN-3q-L2A"/>
-                            <constraint firstItem="2F5-2R-J3a" firstAttribute="centerX" secondItem="uu3-0x-fob" secondAttribute="centerX" id="Kxw-10-zfh"/>
                             <constraint firstItem="49h-m6-Xnv" firstAttribute="trailing" secondItem="x1J-99-6qg" secondAttribute="trailing" id="bN5-bA-QNw"/>
                             <constraint firstItem="x1J-99-6qg" firstAttribute="leading" secondItem="49h-m6-Xnv" secondAttribute="leading" id="iYz-rL-sve"/>
                             <constraint firstItem="49h-m6-Xnv" firstAttribute="trailing" secondItem="q3g-dt-07M" secondAttribute="trailing" constant="20" id="ljm-FY-NJb"/>
                             <constraint firstItem="x1J-99-6qg" firstAttribute="top" secondItem="49h-m6-Xnv" secondAttribute="top" id="oh3-A4-JKu"/>
-                            <constraint firstItem="2F5-2R-J3a" firstAttribute="leading" secondItem="49h-m6-Xnv" secondAttribute="leading" constant="15" id="qGl-k9-nyy"/>
                             <constraint firstItem="49h-m6-Xnv" firstAttribute="bottom" secondItem="q3g-dt-07M" secondAttribute="bottom" constant="20" id="y3M-Cq-z2O"/>
-                            <constraint firstItem="2F5-2R-J3a" firstAttribute="centerY" secondItem="uu3-0x-fob" secondAttribute="centerY" id="ziG-2b-uko"/>
                         </constraints>
                         <connections>
-                            <outlet property="noRecipeLabel" destination="2F5-2R-J3a" id="mUU-2N-ldh"/>
                             <outlet property="postPageButton" destination="q3g-dt-07M" id="wYH-jc-r9o"/>
                             <outlet property="tableView" destination="x1J-99-6qg" id="7qg-4c-geG"/>
                         </connections>

--- a/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
+++ b/Kikurage/ScreenModule/Recipe/ViewController/RecipeViewController.swift
@@ -13,6 +13,7 @@ import RxSwift
 
 class RecipeViewController: UIViewController, UIViewControllerNavigatable, RecipeAccessable {
     private var baseView: RecipeBaseView { self.view as! RecipeBaseView } // swiftlint:disable:this force_cast
+    private var emptyView: UIView!
     private var viewModel: RecipeViewModel!
 
     private let diposeBag = RxSwift.DisposeBag()
@@ -66,6 +67,13 @@ extension RecipeViewController {
         refresh.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         baseView.setRefreshControlInTableView(refresh)
     }
+    private func displayEmptyView(recipes: [KikurageRecipeTuple]) {
+        if recipes.isEmpty {
+            emptyView = addEmptyView(type: .notFoundRecipe)
+        } else {
+            emptyView?.removeFromSuperview()
+        }
+    }
 }
 
 // MARK: - Rx
@@ -86,12 +94,12 @@ extension RecipeViewController {
                     HUD.hide()
                     self?.baseView.tableView.refreshControl?.endRefreshing()
                     self?.baseView.tableView.reloadData()
-                    self?.baseView.noRecipeLabelIsHidden(!recipes.isEmpty)
+                    self?.displayEmptyView(recipes: recipes)
                 }
             }
         )
         .disposed(by: diposeBag)
-        
+
         viewModel.output.error.subscribe(
             onNext: { [weak self] error in
                 DispatchQueue.main.async {

--- a/Kikurage/ScreenModule/SideMenu/Child/Dictionary/BaseView/Twitter/DictionaryTwitterBaseView.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Dictionary/BaseView/Twitter/DictionaryTwitterBaseView.swift
@@ -12,15 +12,6 @@ class DictionaryTwitterBaseView: UIView {
     @IBOutlet private(set) weak var tableView: UITableView!
     @IBOutlet private weak var loadingIndicatorView: UIActivityIndicatorView!
 
-    private let noTweetsLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 17, weight: .bold)
-        label.textColor = .darkGray
-        label.textAlignment = .center
-        label.text = R.string.localizable.side_menu_dictionary_twitter_no_tweets()
-        return label
-    }()
-
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -44,12 +35,5 @@ extension DictionaryTwitterBaseView {
     func stopLoadingIndicator() {
         loadingIndicatorView.isHidden = true
         loadingIndicatorView.stopAnimating()
-    }
-    func showTweetsEmptyView(isEmpty: Bool) {
-        if isEmpty {
-            tableView.backgroundView = noTweetsLabel
-        } else {
-            tableView.backgroundView = nil
-        }
     }
 }

--- a/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/Twitter/DictionaryTwitterViewController.swift
+++ b/Kikurage/ScreenModule/SideMenu/Child/Dictionary/ViewController/Twitter/DictionaryTwitterViewController.swift
@@ -8,8 +8,9 @@
 
 import UIKit
 
-class DictionaryTwitterViewController: UIViewController {
+class DictionaryTwitterViewController: UIViewController, UIViewControllerNavigatable {
     private var baseView: DictionaryTwitterBaseView { self.view as! DictionaryTwitterBaseView } // swiftlint:disable:this force_cast
+    private var emptyView: UIView!
     private var viewModel: DictionaryTwitterViewModel!
 
     override func viewDidLoad() {
@@ -19,6 +20,18 @@ class DictionaryTwitterViewController: UIViewController {
         baseView.configTableView(delegate: self, dataSource: viewModel)
 
         loadTweets()
+    }
+}
+
+// MARK: - Initialize
+
+extension DictionaryTwitterViewController {
+    private func displayEmptyView(tweets: [Tweet.Status]) {
+        if tweets.isEmpty {
+            emptyView = addEmptyView(type: .notFoundTweets)
+        } else {
+            emptyView?.removeFromSuperview()
+        }
     }
 }
 
@@ -42,7 +55,7 @@ extension DictionaryTwitterViewController: DictionaryTwitterViewModelDelegate {
     func dictionaryTwitterViewModelDidSuccessGetTweets(_ dictionaryTwitterViewModel: DictionaryTwitterViewModel) {
         DispatchQueue.main.async {
             self.baseView.stopLoadingIndicator()
-            self.baseView.showTweetsEmptyView(isEmpty: dictionaryTwitterViewModel.tweets.isEmpty)
+            self.displayEmptyView(tweets: dictionaryTwitterViewModel.tweets)
             self.baseView.tableView.reloadData()
         }
     }
@@ -50,7 +63,7 @@ extension DictionaryTwitterViewController: DictionaryTwitterViewModelDelegate {
         DispatchQueue.main.async {
             self.baseView.stopLoadingIndicator()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: nil, okButtonTitle: R.string.localizable.common_alert_ok_btn_ok(), cancelButtonTitle: nil) { [weak self] in
-                self?.baseView.showTweetsEmptyView(isEmpty: dictionaryTwitterViewModel.tweets.isEmpty)
+                self?.displayEmptyView(tweets: dictionaryTwitterViewModel.tweets)
             }
         }
     }

--- a/Kikurage/Utility/Extension/UIViewController+Extension.swift
+++ b/Kikurage/Utility/Extension/UIViewController+Extension.swift
@@ -54,7 +54,7 @@ extension UIViewControllerNavigatable where Self: UIViewController {
         nc.navigationBar.scrollEdgeAppearance = nc.navigationBar.standardAppearance
     }
     func addEmptyView(type: EmptyType) -> UIView {
-        let _view = EmptyView(type: .notFoundCultivation)
+        let _view = EmptyView(type: type)
         let hostingVC = UIHostingController(rootView: _view)
         addChild(hostingVC)
         hostingVC.didMove(toParent: self)

--- a/Kikurage/Utility/Extension/UIViewController+Extension.swift
+++ b/Kikurage/Utility/Extension/UIViewController+Extension.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 import SafariServices
 
 // MEMO: UIViewControllerにExtensionすると将来的にメソッド名が衝突する可能性があるため、独自プロトコルに定義し、そのプロトコルのExtensionで拡張する方針
@@ -24,6 +25,9 @@ protocol UIViewControllerNavigatable {
     func openImagePicker()
     ///  iOS15対策：NavigationBarの背景色を設定（iOS15、NavBar背景色が透明になる）
     func adjustNavigationBarBackgroundColor()
+    /// Display empty view.
+    /// - Returns: Empty view for holding in VC. It is used when view is removed from VC with `removeFromSuperview()`.
+    func addEmptyView(type: EmptyType) -> UIView
 }
 
 extension UIViewControllerNavigatable where Self: UIViewController {
@@ -48,5 +52,24 @@ extension UIViewControllerNavigatable where Self: UIViewController {
         appearance.backgroundColor = .systemGroupedBackground
         nc.navigationBar.standardAppearance = appearance
         nc.navigationBar.scrollEdgeAppearance = nc.navigationBar.standardAppearance
+    }
+    func addEmptyView(type: EmptyType) -> UIView {
+        let _view = EmptyView(type: .notFoundCultivation)
+        let hostingVC = UIHostingController(rootView: _view)
+        addChild(hostingVC)
+        hostingVC.didMove(toParent: self)
+
+        hostingVC.view.frame = view.bounds
+        hostingVC.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(hostingVC.view)
+
+        NSLayoutConstraint.activate([
+            hostingVC.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        return hostingVC.view
     }
 }

--- a/Kikurage/Utility/View/EmptyView.swift
+++ b/Kikurage/Utility/View/EmptyView.swift
@@ -12,10 +12,19 @@ struct EmptyView: View {
     let type: EmptyType
 
     var body: some View {
-        Text(type.title)
-            .font(.headline)
-            .bold()
-            .foregroundColor(.gray)
+        VStack(alignment: .center, spacing: 16) {
+            Spacer()
+            Image(type.iconString)
+                .resizable()
+                .renderingMode(.template)
+                .foregroundColor(.gray)
+                .frame(width: 49, height: 32)
+            Text(type.title)
+                .font(.headline)
+                .bold()
+                .foregroundColor(.gray)
+            Spacer()
+        }
     }
 }
 
@@ -31,6 +40,15 @@ enum EmptyType {
             return R.string.localizable.screen_recipe_no_recipe()
         case .notFoundCultivation:
             return R.string.localizable.screen_cultivation_no_cultivation()
+        }
+    }
+
+    var iconString: String {
+        switch self {
+        case .notFoundRecipe:
+            return "hakase"
+        case .notFoundCultivation:
+            return "hakase"
         }
     }
 }

--- a/Kikurage/Utility/View/EmptyView.swift
+++ b/Kikurage/Utility/View/EmptyView.swift
@@ -33,6 +33,7 @@ struct EmptyView: View {
 enum EmptyType {
     case notFoundCultivation
     case notFoundRecipe
+    case notFoundTweets
 
     var title: String {
         switch self {
@@ -40,6 +41,8 @@ enum EmptyType {
             return R.string.localizable.screen_recipe_no_recipe()
         case .notFoundCultivation:
             return R.string.localizable.screen_cultivation_no_cultivation()
+        case .notFoundTweets:
+            return R.string.localizable.side_menu_dictionary_twitter_no_tweets()
         }
     }
 
@@ -48,6 +51,8 @@ enum EmptyType {
         case .notFoundRecipe:
             return "hakase"
         case .notFoundCultivation:
+            return "hakase"
+        case .notFoundTweets:
             return "hakase"
         }
     }

--- a/Kikurage/Utility/View/EmptyView.swift
+++ b/Kikurage/Utility/View/EmptyView.swift
@@ -1,0 +1,42 @@
+//
+//  EmptyView.swift
+//  Kikurage
+//
+//  Created by Shusuke Ota on 2022/8/27.
+//  Copyright © 2022 shusuke. All rights reserved.
+//
+
+import SwiftUI
+
+struct EmptyView: View {
+    let type: EmptyType
+
+    var body: some View {
+        Text(type.title)
+            .font(.headline)
+            .bold()
+            .foregroundColor(.gray)
+    }
+}
+
+// MARK: - Type
+
+enum EmptyType {
+    case notFoundCultivation
+    case notFoundRecipe
+
+    var title: String {
+        switch self {
+        case .notFoundRecipe:
+            return R.string.localizable.screen_recipe_no_recipe()
+        case .notFoundCultivation:
+            return R.string.localizable.screen_cultivation_no_cultivation()
+        }
+    }
+}
+
+struct EmptyView_Previews: PreviewProvider {
+    static var previews: some View {
+        EmptyView(type: .notFoundRecipe)
+    }
+}


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🔧 改善  

## やったこと
- タイトルの通り
- 対象画面は、料理記録一覧・栽培記録一覧

<img width=300 src="https://user-images.githubusercontent.com/33107697/187058239-7f3145dc-26bb-4535-b51d-f19812cc8c23.png">

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- iPhonseSE2nd / iOS13.5.1、iPhone11 Simulator / iOS15.4
- リストがない場合、EmptyViewのみが表示されること
- EmptyView表示⇄リスト表示の切り替えができること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- LaunchScreenで表示する読み込み用スピナーは画面遷移後にremoveするようにした
