### PR TITLE
UseCase追加

### DIFF
--- a/Kikurage.xcodeproj/project.pbxproj
+++ b/Kikurage.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		9CDAFBF824E4BC1400E56550 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDAFBF724E4BC1400E56550 /* UITextField+Extension.swift */; };
 		9CDD1F6425A68521006DA852 /* CommunicationBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDD1F6325A68521006DA852 /* CommunicationBaseView.swift */; };
 		9CDD1FC225A69040006DA852 /* DeviceRegisterBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDD1FC125A69040006DA852 /* DeviceRegisterBaseView.swift */; };
+		9CDE8BE12B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CDE8BE02B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift */; };
 		9CE0184329B46C9B00365E95 /* WiFiSelectDeviceBaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0184229B46C9B00365E95 /* WiFiSelectDeviceBaseView.swift */; };
 		9CE0184529B46CBE00365E95 /* WiFiSelectDeviceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0184429B46CBE00365E95 /* WiFiSelectDeviceViewController.swift */; };
 		9CE0184729B46CCB00365E95 /* WiFiSelectDeviceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0184629B46CCB00365E95 /* WiFiSelectDeviceViewModel.swift */; };
@@ -467,6 +468,7 @@
 		9CDAFBF724E4BC1400E56550 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
 		9CDD1F6325A68521006DA852 /* CommunicationBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommunicationBaseView.swift; sourceTree = "<group>"; };
 		9CDD1FC125A69040006DA852 /* DeviceRegisterBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceRegisterBaseView.swift; sourceTree = "<group>"; };
+		9CDE8BE02B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadKikurageStateWithUserUseCase.swift; sourceTree = "<group>"; };
 		9CE0184229B46C9B00365E95 /* WiFiSelectDeviceBaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiSelectDeviceBaseView.swift; sourceTree = "<group>"; };
 		9CE0184429B46CBE00365E95 /* WiFiSelectDeviceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiSelectDeviceViewController.swift; sourceTree = "<group>"; };
 		9CE0184629B46CCB00365E95 /* WiFiSelectDeviceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiSelectDeviceViewModel.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				9C82B415253037AB00E650B5 /* Constant */,
 				9C73CCD026D53F3C00B4DE55 /* Utility */,
 				9CA7F3342537FD75005BED9C /* Entity */,
+				9CDE8BDF2B4574580078B318 /* UseCase */,
 				9CA7F36D25381EF8005BED9C /* Repository */,
 				9CA2043D271C76A000D65DD7 /* Screen */,
 				9C1ACF512225768A00A3D4D1 /* Assets.xcassets */,
@@ -1552,6 +1555,14 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		9CDE8BDF2B4574580078B318 /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+				9CDE8BE02B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift */,
+			);
+			path = UseCase;
+			sourceTree = "<group>";
+		};
 		9CE0183129B46A8300365E95 /* WiFi */ = {
 			isa = PBXGroup;
 			children = (
@@ -2293,6 +2304,7 @@
 				9C1ACF4B2225768A00A3D4D1 /* AppDelegate.swift in Sources */,
 				9CAFDC0D278038F200C40094 /* AccountSettingBaseView.swift in Sources */,
 				9C82B42425305E6C00E650B5 /* UIView+Extension.swift in Sources */,
+				9CDE8BE12B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift in Sources */,
 				9CE1EE4027D4BFB500B5BE9C /* CustomNavigationController.swift in Sources */,
 				9CE0184D29B46D0500365E95 /* WiFiListViewModel.swift in Sources */,
 				9C7DCE9C26EE158D00F62DF8 /* FirebaseAPIError.swift in Sources */,

--- a/Kikurage/App/AppPresenter.swift
+++ b/Kikurage/App/AppPresenter.swift
@@ -12,10 +12,10 @@ import KikurageFeature
 
 protocol AppPresenterDelegate: AnyObject {
     /// きくらげ情報の取得に成功した
-    func didSuccessGetKikurageInfo(kikurageInfo: (user: KikurageUser?, state: KikurageState?))
+    func appPresenterDidSuccessGetKikurageInfo(_ appPresenter: AppPresenter?, kikurageInfo: (user: KikurageUser?, state: KikurageState?))
     /// きくらげ情報の取得に失敗した
     /// - Parameter errorMessage: エラーメッセージ
-    func didFailedGetKikurageInfo(errorMessage: String)
+    func appPresenterDidFailedGetKikurageInfo(_ appPresenter: AppPresenter?, errorMessage: String)
 }
 
 class AppPresenter {
@@ -38,9 +38,9 @@ extension AppPresenter {
         loadKikurageStateWithUserUseCase.invoke(uid: userID) { [weak self] responses in
             switch responses {
             case .success(let res):
-                self?.delegate?.didSuccessGetKikurageInfo(kikurageInfo: (user: res.user, state: res.state))
+                self?.delegate?.appPresenterDidSuccessGetKikurageInfo(self, kikurageInfo: (user: res.user, state: res.state))
             case .failure(let error):
-                self?.delegate?.didFailedGetKikurageInfo(errorMessage: error.description())
+                self?.delegate?.appPresenterDidFailedGetKikurageInfo(self, errorMessage: error.description())
             }
         }
     }

--- a/Kikurage/App/AppRootController.swift
+++ b/Kikurage/App/AppRootController.swift
@@ -131,7 +131,7 @@ extension AppRootController {
 // MARK: - AppPresenter Delegate
 
 extension AppRootController: AppPresenterDelegate {
-    func didSuccessGetKikurageInfo(kikurageInfo: (user: KikurageUser?, state: KikurageState?)) {
+    func appPresenterDidSuccessGetKikurageInfo(_ appPresenter: AppPresenter?, kikurageInfo: (user: KikurageUser?, state: KikurageState?)) {
         if let user = kikurageInfo.user {
             FirebaseAnalyticsHelper.setUserProperty()
             FirebaseAnalyticsHelper.setUserID(user.productKey)
@@ -141,7 +141,7 @@ extension AppRootController: AppPresenterDelegate {
         }
     }
 
-    func didFailedGetKikurageInfo(errorMessage: String) {
+    func appPresenterDidFailedGetKikurageInfo(_ appPresenter: AppPresenter?, errorMessage: String) {
         DispatchQueue.main.async {
             self.showTopPage()
         }

--- a/Kikurage/App/AppRootController.swift
+++ b/Kikurage/App/AppRootController.swift
@@ -26,13 +26,13 @@ class AppRootController: UIViewController {
         super.viewDidLoad()
         initHUD()
 
-        presenter = AppPresenter(kikurageStateRepository: KikurageStateRepository(), kikurageUserRepository: KikurageUserRepository(), firebaseRemoteCofigRepository: FirebaseRemoteConfigRepository())
+        presenter = AppPresenter(firebaseRemoteCofigRepository: FirebaseRemoteConfigRepository())
         presenter.delegate = self
 
         fetchRemoteConfig()
 
         if LoginHelper.shared.isLogin {
-            presenter.loadKikurageUser()
+            presenter.login()
         } else {
             showTopPage()
         }

--- a/Kikurage/Entity/Request/KikurageStateRequest.swift
+++ b/Kikurage/Entity/Request/KikurageStateRequest.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
 import Foundation
 
 struct KikurageStateRequest: FirestoreRequestProtocol {

--- a/Kikurage/Entity/Request/KikurageUserRequest.swift
+++ b/Kikurage/Entity/Request/KikurageUserRequest.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
 import Foundation
 
 struct KikurageUserRequest: FirestoreRequestProtocol {

--- a/Kikurage/Entity/Response/KikurageCultivation.swift
+++ b/Kikurage/Entity/Response/KikurageCultivation.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import Foundation
 import FirebaseFirestore
+import Foundation
 
 typealias KikurageCultivationTuple = (data: KikurageCultivation, documentID: String)
 

--- a/Kikurage/Repository/CultivationRepository.swift
+++ b/Kikurage/Repository/CultivationRepository.swift
@@ -6,7 +6,8 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
+import FirebaseStorage
 import RxSwift
 import UIKit
 

--- a/Kikurage/Repository/FirestoreClient.swift
+++ b/Kikurage/Repository/FirestoreClient.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
 import Foundation
 import RxSwift
 

--- a/Kikurage/Repository/KikurageStateListenerRepository.swift
+++ b/Kikurage/Repository/KikurageStateListenerRepository.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
 import RxSwift
 
 protocol KikurageStateListenerRepositoryProtocol {

--- a/Kikurage/Repository/KikurageStateRepository.swift
+++ b/Kikurage/Repository/KikurageStateRepository.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import Firebase
 import FirebaseFirestoreSwift
 import RxSwift
 

--- a/Kikurage/Repository/KikurageUserRepository.swift
+++ b/Kikurage/Repository/KikurageUserRepository.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import Firebase
 import FirebaseFirestoreSwift
 
 protocol KikurageUserRepositoryProtocol {

--- a/Kikurage/Repository/RecipeRepository.swift
+++ b/Kikurage/Repository/RecipeRepository.swift
@@ -6,7 +6,8 @@
 //  Copyright © 2020 shusuke. All rights reserved.
 //
 
-import Firebase
+import FirebaseFirestore
+import FirebaseStorage
 import RxSwift
 import UIKit
 

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -16,7 +16,7 @@ class LoginViewController: UIViewController, UIViewControllerNavigatable, TopAcc
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.title = R.string.localizable.screen_login_title()
-        viewModel = LoginViewModel(signUpRepository: SignUpRepository(), loginRepository: LoginRepository(), kikurageStateRepository: KikurageStateRepository(), kikurageUserRepository: KikurageUserRepository())
+        viewModel = LoginViewModel(signUpRepository: SignUpRepository(), loginRepository: LoginRepository())
 
         setDelegate()
         adjustNavigationBarBackgroundColor()

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -80,7 +80,7 @@ extension LoginViewController: LoginViewModelDelegate {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: errorMessage, okButtonTitle: "OK", cancelButtonTitle: nil) { [weak self] in
                 self?.baseView.initTextFields()
-                loginViewModel?.resetLoginInfo()
+                loginViewModel?.resetLoginInputs()
             }
         }
     }

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -68,10 +68,10 @@ extension LoginViewController: UITextFieldDelegate {
 // MARK: - LoginViewModel Delegate
 
 extension LoginViewController: LoginViewModelDelegate {
-    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel) {
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState)  {
         DispatchQueue.main.async {
             HUD.hide()
-            self.transitionHomePage()
+            self.pushToHome(kikurageState: state, kikurageUser: user)
         }
     }
 
@@ -83,12 +83,5 @@ extension LoginViewController: LoginViewModelDelegate {
                 loginViewModel.initLoginInfo()
             }
         }
-    }
-
-    private func transitionHomePage() {
-        guard let kikurageState = viewModel.kikurageState, let kikurageUser = viewModel.kikurageUser else {
-            return
-        }
-        pushToHome(kikurageState: kikurageState, kikurageUser: kikurageUser)
     }
 }

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -68,19 +68,19 @@ extension LoginViewController: UITextFieldDelegate {
 // MARK: - LoginViewModel Delegate
 
 extension LoginViewController: LoginViewModelDelegate {
-    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState) {
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel?, user: KikurageUser, state: KikurageState) {
         DispatchQueue.main.async {
             HUD.hide()
             self.pushToHome(kikurageState: state, kikurageUser: user)
         }
     }
 
-    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel, with errorMessage: String) {
+    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel?, with errorMessage: String) {
         DispatchQueue.main.async {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: errorMessage, okButtonTitle: "OK", cancelButtonTitle: nil) { [weak self] in
                 self?.baseView.initTextFields()
-                loginViewModel.resetLoginInfo()
+                loginViewModel?.resetLoginInfo()
             }
         }
     }

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -80,7 +80,7 @@ extension LoginViewController: LoginViewModelDelegate {
             HUD.hide()
             UIAlertController.showAlert(style: .alert, viewController: self, title: errorMessage, message: errorMessage, okButtonTitle: "OK", cancelButtonTitle: nil) { [weak self] in
                 self?.baseView.initTextFields()
-                loginViewModel.initLoginInfo()
+                loginViewModel.resetLoginInfo()
             }
         }
     }

--- a/Kikurage/Screen/Login/ViewController/LoginViewController.swift
+++ b/Kikurage/Screen/Login/ViewController/LoginViewController.swift
@@ -56,9 +56,9 @@ extension LoginViewController: UITextFieldDelegate {
         }
         switch textField {
         case baseView.emailTextField:
-            viewModel.email = text
+            viewModel.setEmail(text)
         case baseView.passwordTextField:
-            viewModel.password = text
+            viewModel.setPassword(text)
         default:
             break
         }
@@ -68,7 +68,7 @@ extension LoginViewController: UITextFieldDelegate {
 // MARK: - LoginViewModel Delegate
 
 extension LoginViewController: LoginViewModelDelegate {
-    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState)  {
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState) {
         DispatchQueue.main.async {
             HUD.hide()
             self.pushToHome(kikurageState: state, kikurageUser: user)

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol LoginViewModelDelegate: AnyObject {
-    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel)
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState)
     func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel, with errorMessage: String)
 }
 
@@ -19,9 +19,6 @@ class LoginViewModel {
     private let loadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol
 
     weak var delegate: LoginViewModelDelegate?
-
-    var kikurageUser: KikurageUser?
-    var kikurageState: KikurageState?
 
     private var loginUser: LoginUser?
     var email: String = ""
@@ -60,9 +57,7 @@ extension LoginViewModel {
                 self?.loadKikurageStateWithUserUseCase.invoke(uid: loginUser.uid) { [weak self] responses in
                     switch responses {
                     case .success(let res):
-                        self?.kikurageUser = res.user
-                        self?.kikurageState = res.state
-                        self?.delegate?.loginViewModelDidSuccessLogin(self!)
+                        self?.delegate?.loginViewModelDidSuccessLogin(self!, user: res.user, state: res.state)
                     case .failure(let error):
                         self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
                     }

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -38,7 +38,7 @@ extension LoginViewModel {
         (email, password)
     }
 
-    func resetLoginInfo() {
+    func resetLoginInputs() {
         email = ""
         password = ""
     }

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -38,7 +38,7 @@ extension LoginViewModel {
         (email, password)
     }
 
-    func initLoginInfo() {
+    func resetLoginInfo() {
         email = ""
         password = ""
     }

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -21,8 +21,8 @@ class LoginViewModel {
     weak var delegate: LoginViewModelDelegate?
 
     private var loginUser: LoginUser?
-    var email: String = ""
-    var password: String = ""
+    private var email: String = ""
+    private var password: String = ""
 
     init(signUpRepository: SignUpRepositoryProtocol, loginRepository: LoginRepositoryProtocol) {
         self.signUpRepository = signUpRepository
@@ -41,6 +41,14 @@ extension LoginViewModel {
     func resetLoginInfo() {
         email = ""
         password = ""
+    }
+
+    func setEmail(_ value: String) {
+        email = value
+    }
+
+    func setPassword(_ value: String) {
+        password = value
     }
     // TODO: email, password の入力バリデーション処理を追加（`VC`の登録ボタン押下時に呼ぶ）
 }

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -27,7 +27,7 @@ class LoginViewModel {
     init(signUpRepository: SignUpRepositoryProtocol, loginRepository: LoginRepositoryProtocol) {
         self.signUpRepository = signUpRepository
         self.loginRepository = loginRepository
-        loadKikurageStateWithUserUseCase = LoadKikurageStateWithUserUseCase(kikurageStateRepository: KikurageStateRepository(), kikurageUserRepository: KikurageUserRepository())
+        self.loadKikurageStateWithUserUseCase = LoadKikurageStateWithUserUseCase(kikurageStateRepository: KikurageStateRepository(), kikurageUserRepository: KikurageUserRepository())
     }
 }
 

--- a/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
+++ b/Kikurage/Screen/Login/ViewModel/LoginViewModel.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 protocol LoginViewModelDelegate: AnyObject {
-    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel, user: KikurageUser, state: KikurageState)
-    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel, with errorMessage: String)
+    func loginViewModelDidSuccessLogin(_ loginViewModel: LoginViewModel?, user: KikurageUser, state: KikurageState)
+    func loginViewModelDidFailedLogin(_ loginViewModel: LoginViewModel?, with errorMessage: String)
 }
 
 class LoginViewModel {
@@ -65,13 +65,13 @@ extension LoginViewModel {
                 self?.loadKikurageStateWithUserUseCase.invoke(uid: loginUser.uid) { [weak self] responses in
                     switch responses {
                     case .success(let res):
-                        self?.delegate?.loginViewModelDidSuccessLogin(self!, user: res.user, state: res.state)
+                        self?.delegate?.loginViewModelDidSuccessLogin(self, user: res.user, state: res.state)
                     case .failure(let error):
-                        self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
+                        self?.delegate?.loginViewModelDidFailedLogin(self, with: error.description())
                     }
                 }
             case .failure(let error):
-                self?.delegate?.loginViewModelDidFailedLogin(self!, with: error.description())
+                self?.delegate?.loginViewModelDidFailedLogin(self, with: error.description())
             }
         }
     }

--- a/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
+++ b/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
@@ -8,8 +8,10 @@
 
 import Foundation
 
+typealias KikurageStateUserTuple = (user: KikurageUser, state: KikurageState)
+
 protocol LoadKikurageStateWithUserUseCaseProtocol {
-    func invoke(uid: String, completion: @escaping (Result<KikurageState, ClientError>) -> Void)
+    func invoke(uid: String, completion: @escaping (Result<KikurageStateUserTuple, ClientError>) -> Void)
 }
 
 class LoadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol {
@@ -21,7 +23,7 @@ class LoadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol
         self.kikurageUserRepository = kikurageUserRepository
     }
     
-    func invoke(uid: String, completion: @escaping (Result<KikurageState, ClientError>) -> Void) {
+    func invoke(uid: String, completion: @escaping (Result<KikurageStateUserTuple, ClientError>) -> Void) {
         let userRequest = KikurageUserRequest(uid: uid)
         kikurageUserRepository.getKikurageUser(request: userRequest) { [weak self] response in
             switch response {
@@ -30,7 +32,7 @@ class LoadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol
                 self?.kikurageStateRepository.getKikurageState(request: stateRequest) { response in
                     switch response {
                     case .success(let kikurageState):
-                        completion(.success(kikurageState))
+                        completion(.success((kikurageUser, kikurageState)))
                     case .failure(let error):
                         completion(.failure(error))
                     }

--- a/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
+++ b/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
@@ -17,12 +17,12 @@ protocol LoadKikurageStateWithUserUseCaseProtocol {
 class LoadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol {
     private let kikurageStateRepository: KikurageStateRepositoryProtocol
     private let kikurageUserRepository: KikurageUserRepositoryProtocol
-    
+
     init(kikurageStateRepository: KikurageStateRepositoryProtocol, kikurageUserRepository: KikurageUserRepositoryProtocol) {
         self.kikurageStateRepository = kikurageStateRepository
         self.kikurageUserRepository = kikurageUserRepository
     }
-    
+
     func invoke(uid: String, completion: @escaping (Result<KikurageStateUserTuple, ClientError>) -> Void) {
         let userRequest = KikurageUserRequest(uid: uid)
         kikurageUserRepository.getKikurageUser(request: userRequest) { [weak self] response in

--- a/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
+++ b/Kikurage/UseCase/LoadKikurageStateWithUserUseCase.swift
@@ -1,0 +1,43 @@
+//
+//  LoadKikurageStateWithUserUseCase.swift
+//  Kikurage
+//
+//  Created by Shusuke Ota on 2024/1/3.
+//  Copyright © 2024 shusuke. All rights reserved.
+//
+
+import Foundation
+
+protocol LoadKikurageStateWithUserUseCaseProtocol {
+    func invoke(uid: String, completion: @escaping (Result<KikurageState, ClientError>) -> Void)
+}
+
+class LoadKikurageStateWithUserUseCase: LoadKikurageStateWithUserUseCaseProtocol {
+    private let kikurageStateRepository: KikurageStateRepositoryProtocol
+    private let kikurageUserRepository: KikurageUserRepositoryProtocol
+    
+    init(kikurageStateRepository: KikurageStateRepositoryProtocol, kikurageUserRepository: KikurageUserRepositoryProtocol) {
+        self.kikurageStateRepository = kikurageStateRepository
+        self.kikurageUserRepository = kikurageUserRepository
+    }
+    
+    func invoke(uid: String, completion: @escaping (Result<KikurageState, ClientError>) -> Void) {
+        let userRequest = KikurageUserRequest(uid: uid)
+        kikurageUserRepository.getKikurageUser(request: userRequest) { [weak self] response in
+            switch response {
+            case .success(let kikurageUser):
+                let stateRequest = KikurageStateRequest(productID: kikurageUser.productKey)
+                self?.kikurageStateRepository.getKikurageState(request: stateRequest) { response in
+                    switch response {
+                    case .success(let kikurageState):
+                        completion(.success(kikurageState))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🔧 改善  

## やったこと
**メイン**
- LoadKikurageStateWithUserUseCaseを追加
- 理由
  - `loadKikurageUser()`と`loadKikurageState()`を呼んでStateを取得する処理が２つのViewModelで定義されておりDRYに反していたため
  - [Android-App](https://github.com/shusuke0812/KikurageApp-Android/tree/develop/native)と同じクラス構成にして保守性を高めるため
-  AppPresenterおよびLoginViewModelにLoadKikurageStateWithUserUseCaseを適用 

**サブ**
- Firebaseライブラリのimportエラーを解消
- LoginVMのプロパティをカプセル化
- AppPresenterのdelegateメソッド名を他のdelegate命名規則に倣って修正

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- 正しいメールアドレスとパスワードを入力してログインしホーム画面が表示されること
- 誤ったメールアドレスもしくはパスワードを入力してログインできないこと（エラーアラートが表示されること）
- ログイン済みの場合、アプリを起動したらホーム画面が表示されること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- なし
