### PR TITLE
SceneDelegate

### DIFF
--- a/Kikurage.xcodeproj/project.pbxproj
+++ b/Kikurage.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		9CCB856929C5E23C00D14338 /* KikurageBluetoothCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCB856829C5E23C00D14338 /* KikurageBluetoothCommand.swift */; };
 		9CCBA01029B5C3F50006F4F6 /* KikurageBluetoothSignal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCBA00F29B5C3F50006F4F6 /* KikurageBluetoothSignal.swift */; };
 		9CCBA01229B5D5A70006F4F6 /* KikurageBluetoothPeripheral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCBA01129B5D5A70006F4F6 /* KikurageBluetoothPeripheral.swift */; };
+		9CCE9EFE2B932F1200D13911 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCE9EFD2B932F1200D13911 /* SceneDelegate.swift */; };
 		9CD1886E29758032008EF1ED /* KikurageBluetoothManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD1886D29758032008EF1ED /* KikurageBluetoothManager.swift */; };
 		9CD2497929D3110B00391C44 /* KikurageBluetoothCompletion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD2497829D3110B00391C44 /* KikurageBluetoothCompletion.swift */; };
 		9CD984EF280174AA009D52A9 /* FirestoreRequestProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD984EE280174AA009D52A9 /* FirestoreRequestProtocol.swift */; };
@@ -461,6 +462,7 @@
 		9CCB856829C5E23C00D14338 /* KikurageBluetoothCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageBluetoothCommand.swift; sourceTree = "<group>"; };
 		9CCBA00F29B5C3F50006F4F6 /* KikurageBluetoothSignal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageBluetoothSignal.swift; sourceTree = "<group>"; };
 		9CCBA01129B5D5A70006F4F6 /* KikurageBluetoothPeripheral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageBluetoothPeripheral.swift; sourceTree = "<group>"; };
+		9CCE9EFD2B932F1200D13911 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		9CD1886D29758032008EF1ED /* KikurageBluetoothManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageBluetoothManager.swift; sourceTree = "<group>"; };
 		9CD2497829D3110B00391C44 /* KikurageBluetoothCompletion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KikurageBluetoothCompletion.swift; sourceTree = "<group>"; };
 		9CD984EE280174AA009D52A9 /* FirestoreRequestProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreRequestProtocol.swift; sourceTree = "<group>"; };
@@ -813,6 +815,7 @@
 			isa = PBXGroup;
 			children = (
 				9CE1EE3C27D4B8DF00B5BE9C /* Navigation */,
+				9CCE9EFD2B932F1200D13911 /* SceneDelegate.swift */,
 				9C1ACF4A2225768A00A3D4D1 /* AppDelegate.swift */,
 				9C9A8DA026DFB9DE006C31E7 /* AppRootController.swift */,
 				9CA7628026E28CBE000F7EE2 /* AppPresenter.swift */,
@@ -2306,6 +2309,7 @@
 				9C82B42425305E6C00E650B5 /* UIView+Extension.swift in Sources */,
 				9CDE8BE12B4574AB0078B318 /* LoadKikurageStateWithUserUseCase.swift in Sources */,
 				9CE1EE4027D4BFB500B5BE9C /* CustomNavigationController.swift in Sources */,
+				9CCE9EFE2B932F1200D13911 /* SceneDelegate.swift in Sources */,
 				9CE0184D29B46D0500365E95 /* WiFiListViewModel.swift in Sources */,
 				9C7DCE9C26EE158D00F62DF8 /* FirebaseAPIError.swift in Sources */,
 				9CE029B027F4969E002BDD30 /* DictionaryViewModel.swift in Sources */,

--- a/Kikurage/App/AppDelegate.swift
+++ b/Kikurage/App/AppDelegate.swift
@@ -15,9 +15,8 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var window: UIWindow?
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        KLogManager.debug()
         FirebaseApp.configure()
         configCrashlyticsUserID()
 
@@ -26,19 +25,20 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         MXMetricManager.shared.add(self)
 
-        openTopPage()
         return true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {}
+    func applicationWillTerminate(_ application: UIApplication) {}
 
-    func applicationDidEnterBackground(_ application: UIApplication) {}
+    // MARK: - UISceneSession Lifecycle
 
-    func applicationWillEnterForeground(_ application: UIApplication) {}
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        KLogManager.debug()
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {}
-
-    func applicationWillTerminate(_ application: UIApplication) {
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        KLogManager.debug()
         MXMetricManager.shared.remove(self)
     }
 }
@@ -46,15 +46,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Private
 
 extension AppDelegate {
-    private func openTopPage() {
-        let window = UIWindow()
-        self.window = window
-        let vc = AppRootController()
-        self.window?.rootViewController = vc
-        self.window?.backgroundColor = .white
-        self.window?.makeKeyAndVisible()
-    }
-
     private func configCrashlyticsUserID() {
         let userID = LoginHelper.shared.kikurageUserID ?? "no id"
         Crashlytics.crashlytics().setUserID(userID)

--- a/Kikurage/App/AppDelegate.swift
+++ b/Kikurage/App/AppDelegate.swift
@@ -69,7 +69,7 @@ extension AppDelegate: MXMetricManagerSubscriber {
             let jsonData = payload.jsonRepresentation()
             let jsonString = String(data: jsonData, encoding: .utf8)
             // ex. send user log to Log server
-            KLogger.debug("\(jsonString)")
+            KLogManager.debug(jsonString ?? "not found")
         }
     }
 
@@ -79,7 +79,7 @@ extension AppDelegate: MXMetricManagerSubscriber {
             let jsonData = payload.jsonRepresentation()
             let jsonString = String(data: jsonData, encoding: .utf8)
             // ex. send user log to Log server
-            KLogger.debug("\(jsonString)")
+            KLogManager.debug(jsonString ?? "not found")
         }
     }
 }

--- a/Kikurage/App/SceneDelegate.swift
+++ b/Kikurage/App/SceneDelegate.swift
@@ -1,0 +1,67 @@
+//
+//  SceneDelegate.swift
+//  Kikurage
+//
+//  Created by Shusuke Ota on 2024/3/2.
+//  Copyright © 2024 shusuke. All rights reserved.
+//
+
+import KikurageFeature
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        KLogManager.debug()
+        guard let windowScene = (scene as? UIWindowScene) else {
+            return
+        }
+        openTopPage(windowScene: windowScene)
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        KLogManager.debug()
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        KLogManager.debug()
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        KLogManager.debug()
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        KLogManager.debug()
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        KLogManager.debug()
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+}
+
+// MARK: - Private
+
+extension SceneDelegate {
+    private func openTopPage(windowScene: UIWindowScene) {
+        window = UIWindow(windowScene: windowScene)
+
+        window?.rootViewController = AppRootController()
+        window?.backgroundColor = .white
+        window?.makeKeyAndVisible()
+    }
+}

--- a/Kikurage/Utility/Plist/Info.plist
+++ b/Kikurage/Utility/Plist/Info.plist
@@ -47,5 +47,22 @@
 	<string>Light</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>to connect kikurage device</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/KikurageFeature/Logger/KikurageLogger.swift
+++ b/KikurageFeature/Logger/KikurageLogger.swift
@@ -32,11 +32,13 @@ public struct KLogManager: KLoggerProtocol {
         static let category = "default"
     }
 
+    private static let filter = "🔥"
+
     private init() {}
 
     private static func klog(level: OSLogType, file: String, function: String, line: Int, message: String) {
         let logger = os.Logger(subsystem: Config.subsystem, category: Config.category)
-        logger.log(level: level, "\(className(from: file)).\(function) #\(line): \(message)")
+        logger.log(level: level, "\(filter): \(className(from: file)).\(function) #\(line): \(message)")
     }
 
     public static func debug(file: String = #file, function: String = #function, line: Int = #line, _ message: String = "") {

--- a/KikurageFeature/Logger/KikurageLogger.swift
+++ b/KikurageFeature/Logger/KikurageLogger.swift
@@ -54,7 +54,7 @@ public struct KLogManager: KLoggerProtocol {
             let className = self.className(from: #file)
             let function = #function
             let line = #line
-            fatalError("DEBUG: [Fatal] \(className).\(function) #\(line): \(message)")
+            fatalError("\(filter): [Fatal] \(className).\(function) #\(line): \(message)")
         #endif
     }
 }


### PR DESCRIPTION
## プルリク内容
<!-- カテゴリ -->
- 🔧 改善  

## やったこと
- Skip （詳細はイシューに記述）
- Logger修正（コンソールでログを閲覧するときに使うフィルター用のワードを追加）

※ push通知タップ後の遷移は別PRで対応

## 確認したこと
<!-- バグの場合はここに再現できる手順を書く、実行テスト環境（シミュレータ or 実機、OSバージョン）も追記する -->
- アプリ起動後、AppDelegate(didFinishLaunchingWithOptions) -> Scene(willConnectTo) -> sceneWillEnterForeground -> sceneDidBecomeActive が呼ばれること
- ログインクレデンシャルが残っている場合、アプリ起動後にホーム画面が表示されること

## 補足
<!-- 参考にした記事、エビデンス等のリンクを貼ったり情報を追記する -->
- なし
